### PR TITLE
Add a Dockerfile for building an image to hold manifests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.dockerignore
+.gitignore
+Dockerfile
+tests
+LICENSE
+Makefile
+OWNERS
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+from registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+RUN microdnf install -y tar gzip && microdnf clean all && rm -rf /var/cache/yum
+
+COPY . /opt/manifests
+RUN cd /opt && \
+    tar -czf odh-manifests.tar.gz manifests && \
+    rm -rf /opt/manifests


### PR DESCRIPTION
This image contains a tarball of the manifests, it is intended
to be used as input for a multistage build. A .dockerignore file
has been added to limit the copy.