### PR TITLE
Disable auth for Prometheus Metrics

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
     app: jupyterhub
   name: jupyterhub-cfg
 data:
-  jupyterhub_config.py: ""
+  jupyterhub_config.py: "c.JupyterHub.authenticate_prometheus = False;"
   jupyterhub_admins: "admin"
   gpu_mode: ""
   singleuser_pvc_size: 2Gi


### PR DESCRIPTION
We need to disable prometheus authentication for metrics for the time
being as a workaround. Relevant PRs upstream are:

1) https://github.com/opendatahub-io/odh-manifests/pull/330
2) https://github.com/opendatahub-io/jupyterhub-odh/pull/77

Once the above PRs are merged in, we should revert this change

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>