### PR TITLE
Sync up with upstream ODH release v1.1.0

### DIFF
--- a/jupyterhub/notebook-images/overlays/build/minimal-notebook-buildconfig.yaml
+++ b/jupyterhub/notebook-images/overlays/build/minimal-notebook-buildconfig.yaml
@@ -21,7 +21,7 @@ spec:
         name: quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.15.0
       env:
       - name: "ENABLE_PIPENV"
-        value: "1"
+        value: "0"
       - name: "THOTH_DRY_RUN"
         value: "1"
       - name: "THOTH_ADVISE"


### PR DESCRIPTION
The pull request cherry picks commits from latest release.
 z-stream release version: v1.1.0
 c3a7e13 testing ci
