### PR TITLE
Sync up with upstream ODH release v1.1.0

### DIFF
--- a/jupyterhub/notebook-images/overlays/build/elyra-notebook-buildconfig.yaml
+++ b/jupyterhub/notebook-images/overlays/build/elyra-notebook-buildconfig.yaml
@@ -8,7 +8,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: s2i-lab-elyra:v0.0.1
+      name: s2i-lab-elyra:v0.0.2
   source:
     git:
       uri: https://github.com/opendatahub-io/s2i-lab-elyra

--- a/jupyterhub/notebook-images/overlays/build/minimal-notebook-buildconfig.yaml
+++ b/jupyterhub/notebook-images/overlays/build/minimal-notebook-buildconfig.yaml
@@ -21,7 +21,7 @@ spec:
         name: quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.15.0
       env:
       - name: "ENABLE_PIPENV"
-        value: "1"
+        value: "0"
       - name: "THOTH_DRY_RUN"
         value: "1"
       - name: "THOTH_ADVISE"

--- a/jupyterhub/notebook-images/overlays/build/spark-minimal-notebook-buildconfig.yaml
+++ b/jupyterhub/notebook-images/overlays/build/spark-minimal-notebook-buildconfig.yaml
@@ -23,7 +23,7 @@ spec:
       - name: "ENABLE_PIPENV"
         value: "1"
       - name: "THOTH_DRY_RUN"
-        value: "1"
+        value: "0"
       - name: "THOTH_ADVISE"
         value: "0"
       - name: "THOTH_PROVENANCE_CHECK"


### PR DESCRIPTION
The pull request cherry picks commits from latest release.
 z-stream release version: v1.1.0
 Picked commits details:
 c3a7e13 testing ci
 ab06255 testing ci 1
 61e21a0 testing ci 2
