### PR TITLE
Add read/write permissions for necessary for dashboard role

### DIFF
--- a/odh-dashboard/base/cluster-role-binding.yaml
+++ b/odh-dashboard/base/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: odh-dashboard
+subjects:
+  - kind: ServiceAccount
+    name: odh-dashboard
+    namespace: redhat-ods-applications
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: odh-dashboard

--- a/odh-dashboard/base/cluster-role.yaml
+++ b/odh-dashboard/base/cluster-role.yaml
@@ -1,0 +1,21 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: odh-dashboard
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - route.openshift.io
+    resources:
+      - routes

--- a/odh-dashboard/base/kustomization.yaml
+++ b/odh-dashboard/base/kustomization.yaml
@@ -5,8 +5,10 @@ commonLabels:
   app.kubernetes.io/part-of: odh-dashboard
 resources:
 - role.yaml
+- cluster-role.yaml
 - service-account.yaml
 - role-binding.yaml
+- cluster-role-binding.yaml
 - deployment.yaml
 - routes.yaml
 - service.yaml

--- a/odh-dashboard/base/role.yaml
+++ b/odh-dashboard/base/role.yaml
@@ -25,6 +25,7 @@ rules:
       - create
       - delete
       - get
+      - list
       - patch
       - update
       - watch
@@ -37,6 +38,7 @@ rules:
       - create
       - delete
       - get
+      - list
       - patch
       - update
       - watch
@@ -48,6 +50,7 @@ rules:
     verbs:
       - create
       - get
+      - list
       - patch
     resources:
       - imagestreams

--- a/odh-dashboard/base/role.yaml
+++ b/odh-dashboard/base/role.yaml
@@ -19,3 +19,35 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ''
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+      - watch
+    resources:
+      - configmaps
+      - secrets
+  - apiGroups:
+      - batch
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+      - watch
+    resources:
+      - cronjobs
+      - jobs
+  - apiGroups:
+      - image.openshift.io
+    verbs:
+      - create
+      - get
+      - patch
+    resources:
+      - imagestreams


### PR DESCRIPTION
In order to handle the self-managed ISVs, we need to be able to search all projects for CSVs and Routes (or at least the project the ISV configures us to look in).

To validate partner managed ISVS are enabled, we need to allow the user to create secrets with user entered values, run jobs based on configured cron jobs, update the cronjobs to un-suspend, and create/update imagestreams in order to run the validation. Configmaps are also used to store the validation results.