### PR TITLE
Update JupyterHub to pull postgresql password from a custom secret

### DIFF
--- a/jupyterhub/jupyterhub/overrides/overlays/jupyterhub-db-deployment-patch/jupyterhub-db-patch.yaml
+++ b/jupyterhub/jupyterhub/overrides/overlays/jupyterhub-db-deployment-patch/jupyterhub-db-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/template/spec/containers/0/env/1/valueFrom/secretKeyRef/name
+  value: jupyterhub-database-password

--- a/jupyterhub/jupyterhub/overrides/overlays/jupyterhub-db-deployment-patch/kustomization.yaml
+++ b/jupyterhub/jupyterhub/overrides/overlays/jupyterhub-db-deployment-patch/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+
+patchesJson6902:
+- target:
+    kind: DeploymentConfig
+    version: v1
+    group: apps.openshift.io
+    name: jupyterhub-db
+  path: jupyterhub-db-patch.yaml

--- a/jupyterhub/jupyterhub/overrides/overlays/jupyterhub-deployment-patch/jupyterhub-patch.yaml
+++ b/jupyterhub/jupyterhub/overrides/overlays/jupyterhub-deployment-patch/jupyterhub-patch.yaml
@@ -1,3 +1,9 @@
 - op: replace
+  path: /spec/template/spec/containers/0/env/1/valueFrom/secretKeyRef/name
+  value: jupyterhub-database-password
+- op: replace
   path: /spec/template/spec/containers/0/env/3/valueFrom/secretKeyRef/name
   value: jupyterhub-prometheus-token-secrets
+- op: replace
+  path: /spec/template/spec/initContainers/0/env/0/valueFrom/secretKeyRef/name
+  value: jupyterhub-database-password


### PR DESCRIPTION
Once this changeset and the deployer changes are merged in we will need to update the database monitor to use the right secret.

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>