### PR TITLE
Add cluster wide get permissions for services

### DIFF
--- a/odh-dashboard/base/cluster-role.yaml
+++ b/odh-dashboard/base/cluster-role.yaml
@@ -16,6 +16,14 @@ rules:
       - list
       - watch
     apiGroups:
+      - ''
+    resources:
+      - services
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
       - route.openshift.io
     resources:
       - routes


### PR DESCRIPTION
Need to list all services on a cluster in order to find the service related to self-managed ISVs (watson studio)