### PR TITLE
removed image trigger to fix retriggering by operator refresh

### DIFF
--- a/jupyterhub/notebook-images/overlays/cuda-11.0.3/cuda-ubi8-build-chain.yaml
+++ b/jupyterhub/notebook-images/overlays/cuda-11.0.3/cuda-ubi8-build-chain.yaml
@@ -48,9 +48,6 @@ items:
   metadata:
     name: "$(cuda_version)-cuda-s2i-core-ubi8"
   spec:
-    triggers:
-      - imageChange: {}
-        type: ImageChange
     source:
       type: Git
       git:
@@ -74,9 +71,6 @@ items:
   metadata:
     name: "$(cuda_version)-cuda-s2i-base-ubi8"
   spec:
-    triggers:
-      - imageChange: {}
-        type: ImageChange
     source:
       type: Git
       git:
@@ -100,9 +94,6 @@ items:
   metadata:
     name: "$(cuda_version)-cuda-s2i-py38-ubi8"
   spec:
-    triggers:
-      - imageChange: {}
-        type: ImageChange
     source:
       type: Git
       git:
@@ -126,9 +117,6 @@ items:
   metadata:
     name: "$(cuda_version)-cuda-s2i-thoth-ubi8-py38"
   spec:
-    triggers:
-      - imageChange: {}
-        type: ImageChange
     source:
       type: Git
       git:

--- a/jupyterhub/notebook-images/overlays/cuda-11.0.3/gpu-notebook.yaml
+++ b/jupyterhub/notebook-images/overlays/cuda-11.0.3/gpu-notebook.yaml
@@ -89,9 +89,6 @@ items:
       git:
         ref: python38
         uri: 'https://github.com/thoth-station/s2i-minimal-notebook'
-    triggers:
-      - type: ConfigChange
-      - type: ImageChange
     resources:
       requests:
         memory: 4Gi
@@ -115,9 +112,6 @@ items:
       git:
         ref: python38
         uri: 'https://github.com/thoth-station/s2i-tensorflow-gpu-notebook'
-    triggers:
-      - type: ConfigChange
-      - type: ImageChange
     resources:
       limits:
         memory: 8Gi
@@ -143,9 +137,6 @@ items:
       git:
         ref: python38
         uri: 'https://github.com/thoth-station/s2i-pytorch-notebook'
-    triggers:
-      - type: ConfigChange
-      - type: ImageChange
     resources:
       limits:
         memory: 8Gi


### PR DESCRIPTION
removed image trigger to fix retriggering by operator refresh
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


As the operator refresh on the components.
the build config schedule a new build due to the image trigger present in it.
this would fix the issue. 