### PR TITLE
Add tensorflow/pytorch simple load test script

### DIFF
--- a/tests/basictests/jupyterhub_load.sh
+++ b/tests/basictests/jupyterhub_load.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+source $TEST_DIR/common
+
+MY_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
+
+source ${MY_DIR}/../util
+
+JH_LOGIN_USER=${OPENSHIFT_USER:-"admin"} #Username used to login to JH
+JH_LOGIN_PASS=${OPENSHIFT_PASS:-"admin"} #Password used to login to JH
+OPENSHIFT_LOGIN_PROVIDER=${OPENSHIFT_LOGIN_PROVIDER:-"htpasswd-provider"} #OpenShift OAuth provider used for login
+JH_AS_ADMIN=${JH_AS_ADMIN:-"true"} #Expect the user to be Admin in JupyterHub
+ODS_CI_REPO_ROOT=${ODS_CI_REPO_ROOT:-"${HOME}/src/ods-ci"}
+
+os::test::junit::declare_suite_start "$MY_SCRIPT"
+
+function test_jupyterhub() {
+    header "Testing JupyterHub installation"
+    echo ${OPENSHIFT_LOGIN_PROVIDER}
+    os::cmd::expect_success "oc project ${ODHPROJECT}"
+    os::cmd::try_until_text "oc get deploymentconfig jupyterhub" "jupyterhub" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get deploymentconfig jupyterhub-db" "jupyterhub-db" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get pods -l deploymentconfig=jupyterhub --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}'" "jupyterhub" $odhdefaulttimeout $odhdefaultinterval
+    runningpods=($(oc get pods -l deploymentconfig=jupyterhub --field-selector="status.phase=Running" -o jsonpath="{$.items[*].metadata.name}"))
+    os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "1"
+    os::cmd::try_until_text "oc get pods -l deploymentconfig=jupyterhub-db --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}'" "jupyterhub-db" $odhdefaulttimeout $odhdefaultinterval
+    runningpods=($(oc get pods -l deploymentconfig=jupyterhub-db --field-selector="status.phase=Running" -o jsonpath="{$.items[*].metadata.name}"))
+    os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "1"
+}
+
+function test_ods_ci() {
+    header "Running ODS-CI automation"
+
+    os::cmd::expect_success "oc project ${ODHPROJECT}"
+    ODH_JUPYTERHUB_URL="https://"$(oc get route jupyterhub -o jsonpath='{.spec.host}')
+    pushd ${HOME}/src/ods-ci
+    #TODO: Add a test that will iterate over all of the notebook using the notebooks in https://github.com/opendatahub-io/testing-notebooks
+    os::cmd::expect_success "run_robot_test.sh --test-artifact-dir ${ARTIFACT_DIR} --test-case ${MY_DIR}/../resources/ods-ci/test-odh-jupyterlab-git-notebook.robot --test-variables-file ${MY_DIR}/../resources/ods-ci/test-variables.yml --test-variable 'ODH_JUPYTERHUB_URL:${ODH_JUPYTERHUB_URL}' --test-variable RESOURCE_PATH:${PWD}/tests/Resources"
+    popd
+}
+
+test_jupyterhub
+test_ods_ci
+
+os::test::junit::declare_suite_end

--- a/tests/resources/ods-ci/test-odh-jupyterlab-git-notebook.robot
+++ b/tests/resources/ods-ci/test-odh-jupyterlab-git-notebook.robot
@@ -1,0 +1,87 @@
+*** Settings ***
+Default Tags     OpenDataHub
+Resource         ${RESOURCE_PATH}/ODS.robot
+Resource         ${RESOURCE_PATH}/Common.robot
+Library          DebugLibrary
+
+Suite Teardown   End Web Test
+
+
+*** Variables ***
+${ODH_JUPYTERHUB_URL}   https://jupyterhub-opendatahub-jupyterhub.apps.my-cluster.test.redhat.com
+
+
+*** Test Cases ***
+Can Launch Jupyterhub
+  Open Browser  ${ODH_JUPYTERHUB_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+
+Can Login to Jupyterhub
+  Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  ${authorization_required} =  Is Service Account Authorization Required
+  Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
+  Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
+
+Can Spawn Notebook
+  # We need to skip this testcase if the user has an existing pod
+  Fix Spawner Status
+  Select Notebook Image  s2i-generic-data-science-notebook
+  Spawn Notebook
+
+Can Launch Tensorflow Load Test Notebook
+
+  Wait for JupyterLab Splash Screen  timeout=30
+  Maybe Select Kernel
+  ${is_launcher_selected} =  Run Keyword And Return Status  JupyterLab Launcher Tab Is Selected
+  Run Keyword If  not ${is_launcher_selected}  Open JupyterLab Launcher
+  Launch a new JupyterLab Document
+  Close Other JupyterLab Tabs
+
+  Maybe Open JupyterLab Sidebar  File Browser
+  Navigate Home In JupyterLab Sidebar
+  Open With JupyterLab Menu  Git  Clone a Repository
+  Input Text  //div[.="Clone a repo"]/../div[contains(@class, "jp-Dialog-body")]//input  https://github.com/red-hat-data-services/notebook-benchmarks
+  Click Element  xpath://div[.="CLONE"]
+
+  Sleep  5
+  Open With JupyterLab Menu  File  Open from Path…
+  Input Text  //div[.="Open Path"]/../div[contains(@class, "jp-Dialog-body")]//input  notebook-benchmarks/tensorflow/TensorFlow-MNIST-Minimal.ipynb
+  Click Element  xpath://div[.="Open"]
+
+  Capture Page Screenshot
+
+  Wait Until TensorFlow-MNIST-Minimal.ipynb JupyterLab Tab Is Selected
+  Close Other JupyterLab Tabs
+
+  Open With JupyterLab Menu  Run  Run All Cells
+  Wait Until JupyterLab Code Cell Is Not Active
+  Capture Page Screenshot
+  JupyterLab Code Cell Error Output Should Not Be Visible
+
+  Capture Page Screenshot
+  #Get the text of the last output cell
+  ${output} =  Get Text  (//div[contains(@class,"jp-OutputArea-output")])[last()]
+  Should Not Match  ${output}  ERROR*
+
+Can Launch Pytorch Load Test Notebook
+  Sleep  5
+  Open With JupyterLab Menu  File  Open from Path…
+  Input Text  //div[.="Open Path"]/../div[contains(@class, "jp-Dialog-body")]//input  notebook-benchmarks/pytorch/PyTorch-MNIST-Minimal.ipynb
+  Click Element  xpath://div[.="Open"]
+
+  Capture Page Screenshot
+
+  Wait Until PyTorch-MNIST-Minimal.ipynb JupyterLab Tab Is Selected
+  Close Other JupyterLab Tabs
+
+  Open With JupyterLab Menu  Run  Run All Cells
+  Wait Until JupyterLab Code Cell Is Not Active
+#  Capture Page Screenshot
+#  JupyterLab Code Cell Error Output Should Not Be Visible
+
+  Capture Page Screenshot
+  #Get the text of the last output cell
+  ${output} =  Get Text  (//div[contains(@class,"jp-OutputArea-output")])[last()]
+  Should Not Match  ${output}  ERROR*
+
+  Logout JupyterLab
+


### PR DESCRIPTION
These test scripts are to check tensorflow/pytorch are runnig well and also get the load test output.
This script `jupyther_load.sh` is using the robot framework example `test-odh-jupyterlab-git-notebook.robot` in `ods-ci`. 

From each jupyter notebook, it extracts the last epoch output and sends the data to a pushgateway server where internal prometheus grabs periodically.  It uses jupyter notebooks in a repo [notebook-benchmarks](https://github.com/red-hat-data-services/notebook-benchmarks)

https://issues.redhat.com/browse/RHODS-345
https://issues.redhat.com/browse/AIISV-41