### PR TITLE
Add epehemer-storage request and limit for cuda build config

### DIFF
--- a/jupyterhub/notebook-images/overlays/cuda-11.0.3/cuda-ubi8-build-chain.yaml
+++ b/jupyterhub/notebook-images/overlays/cuda-11.0.3/cuda-ubi8-build-chain.yaml
@@ -204,9 +204,11 @@ items:
       limits:
         cpu: "2"
         memory: 4Gi
+        ephemeral-storage: 40Gi
       requests:
         cpu: "1"
         memory: 2Gi
+        ephemeral-storage: 40Gi
     completionDeadlineSeconds: 1800
     successfulBuildsHistoryLimit: 1
     failedBuildsHistoryLimit: 1


### PR DESCRIPTION
This build config requires significant disk space and was failing in
clusters with little local storage. This adds explicit resource requests
and limits for the build config to avoid unexpected build pod evictions.
If a node has insufficient disk space, the build will not get scheduled.

This addresses https://issues.redhat.com/browse/RHODS-948