### PR TITLE
Fix permission setting for dashboard builds/imagestreams

### DIFF
--- a/odh-dashboard/base/role.yaml
+++ b/odh-dashboard/base/role.yaml
@@ -54,6 +54,7 @@ rules:
       - patch
     resources:
       - imagestreams
+  - apiGroups:
       - build.openshift.io
     verbs:
       - get


### PR DESCRIPTION
Fixes erroneous setting for builds and imagestreams for the odh-dashboard role

Jira https://issues.redhat.com/browse/RHODS-1414 mentions this issue.

@crobby @Xaenalt