### PR TITLE
Add cluster permission to fetch ConsoleLinks

### DIFF
--- a/odh-dashboard/base/cluster-role.yaml
+++ b/odh-dashboard/base/cluster-role.yaml
@@ -27,3 +27,11 @@ rules:
       - route.openshift.io
     resources:
       - routes
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - console.openshift.io
+    resources:
+      - consolelinks


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHODS-600

Allows the dashboard server to fetch console.openshift.io/consolelinks necessary for route determination of some applications (RHOAM).
