### PR TITLE
Add permissions for job/status and cluster consoles

### DIFF
--- a/odh-dashboard/base/cluster-role.yaml
+++ b/odh-dashboard/base/cluster-role.yaml
@@ -35,3 +35,11 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - operator.openshift.io
+    resources:
+      - consoles

--- a/odh-dashboard/base/role.yaml
+++ b/odh-dashboard/base/role.yaml
@@ -45,6 +45,7 @@ rules:
     resources:
       - cronjobs
       - jobs
+      - jobs/status
   - apiGroups:
       - image.openshift.io
     verbs:


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1624

**Analysis / Root cause**: 
The validation of jobs fails due to permission errors.

**Solution Description**: 
ODH Dashboard need permission to read `job/status` in the current project and `consoles` for the cluster

