### PR TITLE
FIX: Update test kfdef to deploy jh notebooks in same namespace

### DIFF
--- a/tests/setup/kfctl_openshift.yaml
+++ b/tests/setup/kfctl_openshift.yaml
@@ -14,8 +14,6 @@ spec:
       parameters:
         - name: s3_endpoint_url
           value: "s3.odh.com"
-        - name: notebook_destination
-          value: rhods-notebooks
       repoRef:
         name: manifests
         path: jupyterhub/jupyterhub


### PR DESCRIPTION
The is a quick update to fix failing openshift-ci runs that are failing because the `rhods-notebooks` namespace does not exist

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>