### PR TITLE
Allow odh-dashboard to read all cluster CMs

### DIFF
--- a/odh-dashboard/base/cluster-role.yaml
+++ b/odh-dashboard/base/cluster-role.yaml
@@ -28,6 +28,7 @@ rules:
       - ''
     resources:
       - services
+      - configmaps
   - verbs:
       - get
       - list


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHODS-1612 (partial)

Necessary to determine the console branding.

We use the branding to determine if the user can navigate to the Cluster Manager from the current cluster.