### PR TITLE
Add ordering to jupyterhub notebooks

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
@@ -7,6 +7,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/thoth-station/s2i-generic-data-science-notebook"
     opendatahub.io/notebook-image-name: "Standard Data Science"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks"
+    opendatahub.io/notebook-image-order: "20"
   name: s2i-generic-data-science-notebook
 spec:
   lookupPolicy:

--- a/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
@@ -7,6 +7,7 @@ metadata:
     opendatahub.io/notebook-image-url: "https://github.com/thoth-station/s2i-minimal-notebook"
     opendatahub.io/notebook-image-name: "Minimal Python"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
+    opendatahub.io/notebook-image-order: "10"
   name: s2i-minimal-notebook
 spec:
   lookupPolicy:
@@ -16,6 +17,7 @@ spec:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8.6"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.0.16"}, {"name": "Notebook","version": "6.4.0"}]'
       openshift.io/imported-from: quay.io/thoth-station/s2i-minimal-py38-notebook
+      opendatahub.io/default-image: "true"
     from:
       kind: DockerImage
       name: quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.15

--- a/jupyterhub/notebook-images/overlays/cuda-11.0.3/gpu-notebook.yaml
+++ b/jupyterhub/notebook-images/overlays/cuda-11.0.3/gpu-notebook.yaml
@@ -34,6 +34,7 @@ items:
       opendatahub.io/notebook-image-url: "https://github.com/thoth-station/s2i-tensorflow-gpu-notebook"
       opendatahub.io/notebook-image-name: "TensorFlow"
       opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and includes TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
+      opendatahub.io/notebook-image-order: "40"
     name: "tensorflow-gpu"
   spec:
     lookupPolicy:
@@ -56,6 +57,7 @@ items:
       opendatahub.io/notebook-image-url: "https://github.com/thoth-station/s2i-pytorch-notebook"
       opendatahub.io/notebook-image-name: "PyTorch"
       opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and includes PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
+      opendatahub.io/notebook-image-order: "30"
     name: "pytorch-gpu"
   spec:
     lookupPolicy:


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-599
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

To test this issue, add the changed imagestreams to your cluster and verify that their order in the UI is based on their number (Smallest to largest).
