### PR TITLE
[UPSTREAM] Update jupyterhub HA to use non-deprecated image (#478)

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
@@ -190,12 +190,10 @@ spec:
           requests:
             cpu: 50m
             memory: 50Mi
-        image: 'registry.redhat.io/openshift4/ose-leader-elector-rhel8:v4.7'
+        image: 'quay.io/opendatahub/leader-elector:v0.1'
         args:
-          - '--election=jupyterhub-ha-election'
-          - '--election-namespace=$(NAMESPACE)'
-          - '--http=0.0.0.0:4040'
-          - '--id=$(POD_NAME)'
+          - '-node-id=$(POD_NAME)'
+          - '-namespace=$(NAMESPACE)'
         env:
           - name: NAMESPACE
             valueFrom:

--- a/jupyterhub/jupyterhub/base/jupyterhub-role.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-role.yaml
@@ -111,3 +111,25 @@ rules:
   - delete
   - deletecollection
   - watch
+- apiGroups:
+  - build.openshift.io
+  resources:
+  - builds
+  - buildconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
* Update JupyterHub DC to refer to new leader-election image

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>

* Give JupyterHub SA access to Kubernetes lease objects

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1856
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
