### PR TITLE
[UPSTREAM] Removed sidecar liveness probe (#479)

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
@@ -205,37 +205,6 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.name
-        livenessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - >
-              function is_leader_election_ready() {
-                  [ $(curl -s -o /dev/null -w ''%{http_code}'' localhost:4040) == "200" ]
-              }
-              function get_leader() {
-                  echo "$(curl http://localhost:4040 2> /dev/null | python3 -c "import sys, json; print(json.load(sys.stdin)['name'])")"
-              }
-              function is_empty_string() {
-                  # When the sidecar container is not working the name of the leader is an empty string
-                  [ "$(get_leader)" == "" ]
-              };
-              if ! is_leader_election_ready; then
-                  # Sidecar container is not ready yet
-                  exit 0
-              fi
-              if is_empty_string; then
-                  # Sidecar container is returning an empty string, there must be a problem
-                  # Sleep for a while to let the rest of the container to restart too
-                  sleep 9
-                  exit 1
-              else
-                  # Pod is working, we can exit with success
-                  exit 0
-              fi
-          initialDelaySeconds: 40
-          periodSeconds: 10
       initContainers:
       - command:
         - wait-for-database


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-1856
- [X] The Jira story is acked
- [X] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

## Testing Instructions
- Updated the cluster with this version.
- Check if the Jupyterhub pods don't restart when triggered.