### PR TITLE
Switch over to official oauth proxy image for RHODS dashboard

### DIFF
--- a/odh-dashboard/overlays/authentication/deployment.yaml
+++ b/odh-dashboard/overlays/authentication/deployment.yaml
@@ -12,7 +12,7 @@
       - --cookie-secret=SECRET
       - '--openshift-delegate-urls={"/": {"resource": "route", "verb": "get", "name": "rhods-dashboard"}}'
       - --skip-auth-regex=^/metrics
-    image: quay.io/openshift/origin-oauth-proxy:4.7.0
+    image: registry.redhat.io/openshift4/ose-oauth-proxy
     ports:
       - containerPort: 8443
         name: https


### PR DESCRIPTION
Signed-off-by: Anish Asthana <anishasthana1@gmail.com>

https://issues.redhat.com/browse/RHODS-1910
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s):
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
