### PR TITLE
[UPSTREAM] Add liveness and readiness probes for the configmap-puller traefik sidecar container

### DIFF
--- a/jupyterhub/jupyterhub/base/traefik-deployment.yaml
+++ b/jupyterhub/jupyterhub/base/traefik-deployment.yaml
@@ -108,3 +108,23 @@ spec:
           limits:
             cpu: 30m
             memory: 20Mi
+        livenessProbe:
+          exec:
+            command:
+              - cat
+              - /watched/rules.toml
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command:
+              - cat
+              - /watched/rules.toml
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-1975
- [X] The Jira story is acked
- [X] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
