### PR TITLE
[UPSTREAM] Bump up memory limit for cm-puller sidecar (#494)

### DIFF
--- a/jupyterhub/jupyterhub/base/traefik-deployment.yaml
+++ b/jupyterhub/jupyterhub/base/traefik-deployment.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 30m
-            memory: 40Mi
+            memory: 200Mi
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2087
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
