### PR TITLE
Pin oauth proxy image to v4.8 which is known to work on OpenShift 4.8, 4.9

### DIFF
--- a/odh-dashboard/overlays/authentication/deployment.yaml
+++ b/odh-dashboard/overlays/authentication/deployment.yaml
@@ -12,7 +12,7 @@
       - --cookie-secret=SECRET
       - '--openshift-delegate-urls={"/": {"resource": "route", "verb": "get", "name": "rhods-dashboard"}}'
       - --skip-auth-regex=^/metrics
-    image: registry.redhat.io/openshift4/ose-oauth-proxy
+    image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
     ports:
       - containerPort: 8443
         name: https


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] No cherry-pick, upstream uses different images
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2105
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
