### PR TITLE
Added rbac for jupyterhub and odh-dashboard

### DIFF
--- a/jupyterhub/segment-secret-rbac/base/jupyterhub-role.yaml
+++ b/jupyterhub/segment-secret-rbac/base/jupyterhub-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: jupyterhub-segment
+  name: jupyterhub-segment
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/jupyterhub/segment-secret-rbac/base/jupyterhub-rolebinding.yaml
+++ b/jupyterhub/segment-secret-rbac/base/jupyterhub-rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: jupyterhub-segment
+  name: jupyterhub-segment
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jupyterhub-segment
+subjects:
+- kind: ServiceAccount
+  name: jupyterhub-hub
+  namespace: $(jupyterhub_namespace)

--- a/jupyterhub/segment-secret-rbac/base/kustomization.yaml
+++ b/jupyterhub/segment-secret-rbac/base/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- jupyterhub-role.yaml
+- jupyterhub-rolebinding.yaml
+
+commonLabels:
+  opendatahub.io/component: "true"
+  component.opendatahub.io/name: jupyterhub-segment
+
+configMapGenerator:
+- name: parameters
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+- name: jupyterhub_namespace
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.jupyterhub_namespace
+configurations:
+- params.yaml

--- a/jupyterhub/segment-secret-rbac/base/params.env
+++ b/jupyterhub/segment-secret-rbac/base/params.env
@@ -1,0 +1,1 @@
+jupyterhub_namespace=redhat-ods-applications

--- a/jupyterhub/segment-secret-rbac/base/params.yaml
+++ b/jupyterhub/segment-secret-rbac/base/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: subjects/namespace
+  kind: RoleBinding

--- a/odh-dashboard/segment-secret-rbac/base/kustomization.yaml
+++ b/odh-dashboard/segment-secret-rbac/base/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- rhods-dashboard-role.yaml
+- rhods-dashboard-rolebinding.yaml
+
+commonLabels:
+  opendatahub.io/component: "true"
+  component.opendatahub.io/name: rhods-dashboard-segment
+
+configMapGenerator:
+- name: parameters
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+- name: rhods_namespace
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.rhods_namespace
+configurations:
+- params.yaml

--- a/odh-dashboard/segment-secret-rbac/base/params.env
+++ b/odh-dashboard/segment-secret-rbac/base/params.env
@@ -1,0 +1,1 @@
+rhods_namespace=redhat-ods-applications

--- a/odh-dashboard/segment-secret-rbac/base/params.yaml
+++ b/odh-dashboard/segment-secret-rbac/base/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: subjects/namespace
+  kind: RoleBinding

--- a/odh-dashboard/segment-secret-rbac/base/rhods-dashboard-role.yaml
+++ b/odh-dashboard/segment-secret-rbac/base/rhods-dashboard-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: rhods-dashboard-segment
+  name: rhods-dashboard-segment
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/odh-dashboard/segment-secret-rbac/base/rhods-dashboard-rolebinding.yaml
+++ b/odh-dashboard/segment-secret-rbac/base/rhods-dashboard-rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: rhods-dashboard-segment
+  name: rhods-dashboard-segment
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rhods-dashboard-segment
+subjects:
+- kind: ServiceAccount
+  name: rhods-dashboard
+  namespace: $(rhods_namespace)


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-871
- [X] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

## Testing instructions

### ODH-Dashboard
1. Deploy this PR with the [ODH-Dashboard PR](https://github.com/red-hat-data-services/odh-dashboard/pull/178).
2. Ensure both `segment-key-secret` secret and `rhods-segment-key-enabled` configmap are deployed in the apps Namespace.
3. Check that the `rhods-segment-key-enabled` is set to **false**.
<img width="2245" alt="Screenshot 2022-01-28 at 18 18 37" src="https://user-images.githubusercontent.com/16117276/151605411-e3da82a4-5518-48bf-8b78-a23f8fdc206b.png">
4. Open odh dashboard and inspect network, you should find a network call called `/segment-key` with an empty *write key*.
<img width="1728" alt="odh_dashboard_false" src="https://user-images.githubusercontent.com/16117276/149492295-33b06ced-c128-4b2d-9845-7ae9e9ceeb7a.png">
5. Additionally segment should be tracking the interaction.
6. Now change `rhods-segment-key-enabled` to **true**.
<img width="2228" alt="Screenshot 2022-01-28 at 18 18 15" src="https://user-images.githubusercontent.com/16117276/151605599-1ad4cd36-ff1c-4d76-afbe-2859fb2e4e57.png">
7. Reload odh dashboard and now `/segment-key` should filled with the key.
<img width="1728" alt="odh_dashboard_true" src="https://user-images.githubusercontent.com/16117276/149492355-a12c2ed5-7500-40fa-83ed-5718b46298e3.png">

### Jupyterhub Singleuser Profiles
1. Deploy this PR with the [ODH Deployer](https://github.com/red-hat-data-services/odh-deployer/pull/200).
2. Ensure both `segment-key-secret` secret  is deployed in `redhat-ods-applications` namespace and `rhods-segment-key-enabled` inside `addon-managed-odh-parameters` is deployed in `redhat-ods-operator`
3. Check that the `rhods-segment-key-enabled` is set to **false**.
<img width="2245" alt="Screenshot 2022-01-28 at 18 18 37" src="https://user-images.githubusercontent.com/16117276/151605411-e3da82a4-5518-48bf-8b78-a23f8fdc206b.png">
4. Open jupyterhub, and when selecting the **notebook server**  inspect network, you should find a network call called `/instance` with the *write key* empty.
<img width="1728" alt="jupyterhub_true" src="https://user-images.githubusercontent.com/16117276/149492703-5378294d-7e33-4b04-a99d-535883b456ba.png">
5. Additionally segment should be tracking the interaction.
6. Now change `rhods-segment-key-enabled` to **true**.
<img width="2228" alt="Screenshot 2022-01-28 at 18 18 15" src="https://user-images.githubusercontent.com/16117276/151605599-1ad4cd36-ff1c-4d76-afbe-2859fb2e4e57.png">
7. Reload jupyterhub and now `/instance` should be contain the key.
<img width="1728" alt="jupyterhub_false" src="https://user-images.githubusercontent.com/16117276/149492729-ab49e258-8005-401f-891d-88bac0f9be1d.png">
