### PR TITLE
Remove jupyterhub-cfg configmap

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-configmap.yaml
@@ -2,21 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: jupyterhub
-  name: jupyterhub-cfg
-data:
-  jupyterhub_config.py: ""
-
-  jupyterhub_admins: "admin"
-  gpu_mode: ""
-  singleuser_pvc_size: 20Gi
-  notebook_destination: "$(notebook_destination)"
-
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
     app: jupyterhub-ha-sidecar
   name: sidecar-probe
 data:

--- a/jupyterhub/jupyterhub/base/kustomization.yaml
+++ b/jupyterhub/jupyterhub/base/kustomization.yaml
@@ -38,10 +38,10 @@ vars:
 - name: namespace
   objref:
     kind: ConfigMap
-    name: jupyterhub-cfg
+    name: parameters
     apiVersion: v1
   fieldref:
-    fieldpath: metadata.namespace
+    fieldpath: data.namespace
 - name: storage_class
   objref:
     kind: ConfigMap

--- a/jupyterhub/jupyterhub/base/params.env
+++ b/jupyterhub/jupyterhub/base/params.env
@@ -5,3 +5,4 @@ jupyterhub_secret=jupyterhub
 notebook_destination=
 traefik_credentials_secret=traefik-credentials
 jupyterhub_rds_secret=jupyterhub-rds-secret
+namespace=redhat-ods-applications


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s):  https://issues.redhat.com/browse/RHODS-2638
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

Related PR: https://github.com/red-hat-data-services/odh-deployer/pull/212 
