### PR TITLE
Add timeout env var to culler

### DIFF
--- a/jupyterhub/jupyterhub/overlays/jupyterhub-idle-culler/deploymentconfig.yaml
+++ b/jupyterhub/jupyterhub/overlays/jupyterhub-idle-culler/deploymentconfig.yaml
@@ -11,6 +11,23 @@ spec:
       labels:
         app: jupyterhub-idle-culler
     spec:
+      initContainers:
+        - name: check-for-jh
+          image: 'quay.io/odh-jupyterhub/jupyterhub-img:v0.3.3'
+          command:
+            - /bin/sh
+            - '-c'
+            - 'while ! curl jupyterhub:8081/hub/api; do sleep 5; done'
+          resources:
+            limits:
+              cpu: 150m
+              memory: 50Mi
+            requests:
+              cpu: 150m
+              memory: 20Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
       containers:
         - name: jupyterhub-idle-culler
           image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.3
@@ -20,9 +37,14 @@ spec:
                 secretKeyRef:
                   name: jupyterhub-idle-culler
                   key: token
+            - name: CULLER_TIMEOUT
+              valueFrom:
+                configMapKeyRef:
+                  name: jupyterhub-cfg
+                  key: culler_timeout
           command:
             - jupyterhub-idle-culler
-            - --timeout=259200  # 3 days
+            - --timeout=$(CULLER_TIMEOUT)  # in seconds
             - --url=jupyterhub:8081/hub/api
   triggers:
     - type: ConfigChange

--- a/jupyterhub/jupyterhub/overlays/jupyterhub-idle-culler/kustomization.yaml
+++ b/jupyterhub/jupyterhub/overlays/jupyterhub-idle-culler/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+bases:
+  - ../../base
 resources:
-- deploymentconfig.yaml
+  - ./deploymentconfig.yaml


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2324
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)


Testing Instructions:
Should be deployed along with https://github.com/red-hat-data-services/odh-deployer/pull/216
Verify that in the `jupyterhub-idle-culler` deployment config, the `--timeout` value in container commands is  `$(CULLER_TIMEOUT)`
Change the value `culler_timeout` in `jupyterhub-cfg` Configmap
Redeploy `jupyterhub-idle-culler` pods
Enter a pod and verify that the `CULLER_TIMEOUT` env var is equal to `culler_timeout` value
Additionally verify that a notebook is culled after `culler_timeout` seconds of inactivity