### PR TITLE
Adding telemetry metrics for consumption based billing

### DIFF
--- a/monitoring/base/rhods-rules.yaml
+++ b/monitoring/base/rhods-rules.yaml
@@ -18,3 +18,7 @@ spec:
       expr: count(count_over_time(kube_pod_container_status_ready{namespace="rhods-notebooks",pod=~"jupyterhub-nb.*"}[1h]))
       labels:
         instance: jupyter-notebooks
+    - record: cluster:usage:consumption:rhods:cpu_requests_runtime
+      expr: sum(kube_pod_container_resource_requests{namespace='rhods-notebooks', resource='cpu'})
+    - record: cluster:usage:consumption:rhods:cpu_limits_runtime
+      expr: sum(kube_pod_container_resource_limits{namespace='rhods-notebooks', resource='cpu'})


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-3373
https://issues.redhat.com/browse/RHODS-3374
- [ ] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

## Testing instructions:

Following is the image to be used to test these changes:
`quay.io/modh/rhods-operator-live-catalog:1.10.0-rhods-3373`

1. Install the RHODS operator using the above image on a PSI/OSD cluster.
2. Spin up two notebook pods
3. In the Prometheus instance, query the CPU requests' record in one panel and the corresponding expression in another. Graphs and table values should match for both.
4. Follow step 3 for CPU limits' record and expression as well, to check that both match.