### PR TITLE
Update JH Cluster Role

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-cluster-role.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-cluster-role.yaml
@@ -22,3 +22,8 @@ rules:
       - ''
     resources:
       - nodes
+      - pods
+      - serviceaccounts
+      - secrets
+      - services
+      - namespaces


### PR DESCRIPTION
This commit updates cluster role for JupyterHub. This is required to access metrics from gpu-operator. These
metrics are used to determine available GPUs for a user.

(cherry picked from commit 1558c644a06d221062c15c0a20454690a0c38b93)

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
