### PR TITLE
Fix downtime lag in custom rollout

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
@@ -32,31 +32,39 @@ spec:
           oc get pod -l "deploymentconfig=jupyterhub" -o jsonpath='{.items[0].metadata.labels.deployment}';
         };
 
-        function generate_payload() {
-          echo '{"kind":"Scale","apiVersion":"autoscaling/v1","metadata":{"name":"'$1'","namespace":"'${OPENSHIFT_DEPLOYMENT_NAMESPACE}'"},"spec":{"replicas": '$2'}}'
+        function scale_replicaset() {
+          oc scale rc $1 --replicas=$2;
         };
 
-        function post_scale() {
-          curl -kL -XPUT -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" https://openshift.default.svc.cluster.local/api/v1/namespaces/${OPENSHIFT_DEPLOYMENT_NAMESPACE}/replicationcontrollers/$1/scale -d @$2;
+        function delete_pods() {
+          oc delete pod --force -l deployment==$1
         };
 
         function get_replicas() {
           oc get rc ${OPENSHIFT_DEPLOYMENT_NAME} -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io\/desired-replicas}'
-        }
+        };
 
-        export TOKEN=$(cat /run/secrets/kubernetes.io/serviceaccount/token);
+        function wait_for_leader_election() {
+          sleep 10;
+        };
+
         export OLD_RC=$(get_latest);
 
-        echo $(generate_payload ${OLD_RC} 0) > /tmp/old.yaml;
-        echo $(generate_payload ${OPENSHIFT_DEPLOYMENT_NAME} $(get_replicas)) > /tmp/new.yaml;
+        if [ -n "${OLD_RC}" ]; then
+          scale_replicaset ${OLD_RC} 1;
+        fi
 
-        post_scale ${OLD_RC} /tmp/old.yaml;
-        post_scale ${OPENSHIFT_DEPLOYMENT_NAME} /tmp/new.yaml;
+        scale_replicaset ${OPENSHIFT_DEPLOYMENT_NAME} $(get_replicas);
 
         while ! oc get pods --field-selector='status.phase==Running' -l deployment=="${OPENSHIFT_DEPLOYMENT_NAME}" 2>/dev/null | grep ${OPENSHIFT_DEPLOYMENT_NAME}; do sleep 1; done;
-        echo "Pods for deplyoment ${OPENSHIFT_DEPLOYMENT_NAME} are Running"
+        echo "Pods for deplyoment ${OPENSHIFT_DEPLOYMENT_NAME} are Running";
 
-        while ! curl http://jupyterhub:8081; do sleep 1; done
+        wait_for_leader_election; 
+
+        scale_replicaset ${OLD_RC} 0; 
+        delete_pods ${OLD_RC};
+
+        while ! curl http://jupyterhub:8081; do sleep 1; done;
 
   template:
     metadata:
@@ -268,7 +276,7 @@ spec:
       - name: config 
         configMap:
             defaultMode: 420
-            name: jupyterhub-cfg 
+            name: jupyterhub-cfg
       - name: sidecar-script
         configMap:
           defaultMode: 511

--- a/jupyterhub/jupyterhub/base/jupyterhub-deployer-role.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-deployer-role.yaml
@@ -1,0 +1,25 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: jupyterhub
+  name: jupyterhub-deployer
+rules:
+  - verbs:
+      - get
+      - watch
+      - list
+      - delete
+    apiGroups:
+      - ''
+    resources:
+      - pods
+  - verbs:
+      - get
+      - watch
+      - list
+      - patch
+    apiGroups:
+      - ''
+    resources:
+      - replicationcontrollers/scale

--- a/jupyterhub/jupyterhub/base/jupyterhub-deployer-rolebinding.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-deployer-rolebinding.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+      app: jupyterhub
+  name: jupyterhub-deployer
+subjects:
+  - kind: ServiceAccount
+    name: deployer
+    namespace: redhat-ods-applications
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jupyterhub-deployer

--- a/jupyterhub/jupyterhub/base/kustomization.yaml
+++ b/jupyterhub/jupyterhub/base/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
 - jupyterhub-spark-operator-configmap.yaml
 - jupyterhub-groups-configmap.yaml
 - jupyterhub-notebook-image-puller-rb.yaml
+- jupyterhub-deployer-role.yaml
+- jupyterhub-deployer-rolebinding.yaml
 - traefik-credentials-secret.yaml
 - traefik-configmap.yaml
 - traefik-deployment.yaml


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-2440
- [X] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
——
**Testing Instructions**

1. Install a base version of rhods (tested with quay.io/modh/qe-catalog-source:v190-7).
2. Install a new version with the following image: quay.io/lferrnan/rhods-operator-live-catalog:1.9.9-1-jupyterhub-downtime.
3. The downtime of jupyterhub should be less than 1 minute and the pods of the old replicaset should be killed instantly.