### PR TITLE
[UPSTREAM] Update Memory limit for Dashboard

### DIFF
--- a/odh-dashboard/base/deployment.yaml
+++ b/odh-dashboard/base/deployment.yaml
@@ -33,11 +33,11 @@ spec:
         - containerPort: 8080
         resources:
           requests:
-            cpu: 300m
-            memory: 500Mi
-          limits:
             cpu: 500m
             memory: 1Gi
+          limits:
+            cpu: 1000m
+            memory: 2Gi
         livenessProbe:
           httpGet:
             path: /api/status


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-4070
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

This PR increase memory limits for Dashboard pod in order to decrease alerts related to `OOMKill` 