### PR TITLE
Add resources to deploy pods of culler

### DIFF
--- a/jupyterhub/jupyterhub/overlays/jupyterhub-idle-culler/deploymentconfig.yaml
+++ b/jupyterhub/jupyterhub/overlays/jupyterhub-idle-culler/deploymentconfig.yaml
@@ -3,6 +3,14 @@ kind: DeploymentConfig
 metadata:
   name: jupyterhub-idle-culler
 spec:
+  strategy:
+    resources:
+      limits:
+        cpu: 150m
+        memory: 50Mi
+      requests:
+        cpu: 150m
+        memory: 50Mi
   selector:
     app: jupyterhub-idle-culler
   replicas: 1


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-3793
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

Live build: [quay.io/mroman_redhat/rhods-operator-live-catalog:1.14.0-j3793-3](http://quay.io/mroman_redhat/rhods-operator-live-catalog:1.14.0-j3793-3)