### PR TITLE
[UPSTREAM] Use JH SA Token to access prometheus GPU data

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-monitoring-rolebinding.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-monitoring-rolebinding.yaml
@@ -1,0 +1,11 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jupyterhub-monitoring
+subjects:
+  - kind: ServiceAccount
+    name: jupyterhub-hub
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view

--- a/jupyterhub/jupyterhub/base/kustomization.yaml
+++ b/jupyterhub/jupyterhub/base/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - jupyterhub-rolebinding.yaml
 - jupyterhub-cluster-role.yaml
 - jupyterhub-cluster-rolebinding.yaml
+- jupyterhub-monitoring-rolebinding.yaml
 - jupyterhub-route.yaml
 - jupyterhub-singleuser-profiles-configmap.yaml
 - jupyterhub-spark-operator-configmap.yaml


### PR DESCRIPTION
(cherry picked from commit f359c1a323b966298b48fc758c627844b300364d)

Jira Issue :

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-4820
- [ ] The Jira story is acked
- [x] Live Build: quay.io/modh/rhods-operator-live-catalog:1.15.0-rhods-4820
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

Testing Steps:
To be tested with https://github.com/red-hat-data-services/jupyterhub-singleuser-profiles/pull/62#issue-1330323972
