### PR TITLE
Update Data Science Pipelines to use MODH images and Update Documentation

### DIFF
--- a/data-science-pipelines/README.md
+++ b/data-science-pipelines/README.md
@@ -9,13 +9,13 @@ Data Science Pipelines is the Open Data Hub's pipeline solution for data scienti
 
 1. The cluster needs to be OpenShift 4.9 or higher
 2. OpenShift Pipelines 1.7.2 or higher needs to be installed on the cluster
-3. The Open Data Hub operator needs to be installed
+3. The Red Hat Openshift Data Science operator needs to be installed
 4. The default installation namespace for Data Science Pipelines is `redhat-ods-applications`. This namespace will need to be created. In case you wish to install in a custom location, create it and update the kfdef as documented below.
 
 ### Installation Steps
 
 1. Ensure that the prerequisites are met.
-2. Apply the kfdef at [kfctl_openshift_ds-pipelines.yaml](https://github.com/opendatahub-io/odh-manifests/blob/master/kfdef/kfctl_openshift_ds-pipelines.yaml). You may need to update the `namespace` field under `metadata` in case you want to deploy in a namespace that isn't `redhat-ods-applications`.
+2. Apply the kfdef at [kfctl_openshift_ds-pipelines.yaml](https://github.com/red-hat-data-services/odh-manifests/blob/master/kfdef/kfctl_openshift_ds-pipelines.yaml). You may need to update the `namespace` field under `metadata` in case you want to deploy in a namespace that isn't `redhat-ods-applications`.
 3. To find the url for Data Science pipelines, you can run the following command.
     ```bash
     $ oc get route -n <kdef_namespace> ds-pipeline-ui -o jsonpath='{.spec.host}'
@@ -38,10 +38,10 @@ This directory contains artifacts for deploying all backend components of Data S
 ### Overlays
 
 1. metadata-store-mariadb: This overlay contains artifacts for deploying a MariaDB database. MySQL-based databases are currently the only supported backend for Data Science Pipelines, so if you don't have an existing MySQL or MariaDB database deployed, this overlay needs to be applied.
-3. ds-pipeline-ui: This overlay contains deployment artifacts for the Data Science Pipelines UI. Deploying Data Science Pipelines without this overlay will result in only the backend artifacts being created.
-4. object-store-minio: This overlay contains artifacts for deploying Minio as the Object Store to store Pipelines artifacts.
-5. default-configs: This overlay applies default configuration files and credentials (for db and s3 stores)
-6. integration-odhdashboard: This overlay adds configurations necessary to integrate AppTiles, Documentation links, etc, for Data Science Pipelines into RHODS Dashboard
+2. ds-pipeline-ui: This overlay contains deployment artifacts for the Data Science Pipelines UI. Deploying Data Science Pipelines without this overlay will result in only the backend artifacts being created.
+3. object-store-minio: This overlay contains artifacts for deploying Minio as the Object Store to store Pipelines artifacts.
+4. default-configs: This overlay applies default configuration files and credentials (for db and s3 stores)
+5. integration-odhdashboard: This overlay adds configurations necessary to integrate AppTiles, Documentation links, etc, for Data Science Pipelines into RHODS Dashboard
 
 ### Prometheus
 

--- a/data-science-pipelines/base/buildconfigs/visualization-server.yaml
+++ b/data-science-pipelines/base/buildconfigs/visualization-server.yaml
@@ -30,6 +30,8 @@ spec:
     git:
       uri: "https://github.com/red-hat-data-services/data-science-pipelines"
       ref: master
+  runPolicy: Serial
   triggers:
+    - type: ConfigChange
     - type: ImageChange
       imageChange: {}

--- a/data-science-pipelines/base/deployments/ds-pipeline-persistenceagent.yaml
+++ b/data-science-pipelines/base/deployments/ds-pipeline-persistenceagent.yaml
@@ -36,7 +36,8 @@ spec:
           livenessProbe:
             exec:
               command:
-                - pidof
+                - test
+                - -x
                 - persistence_agent
             initialDelaySeconds: 30
             periodSeconds: 5
@@ -44,7 +45,8 @@ spec:
           readinessProbe:
             exec:
               command:
-                - pidof
+                - test
+                - -x
                 - persistence_agent
             initialDelaySeconds: 3
             periodSeconds: 5

--- a/data-science-pipelines/base/deployments/ds-pipeline-scheduledworkflow.yaml
+++ b/data-science-pipelines/base/deployments/ds-pipeline-scheduledworkflow.yaml
@@ -35,7 +35,8 @@ spec:
           livenessProbe:
             exec:
               command:
-                - pidof
+                - test
+                - -x
                 - controller
             initialDelaySeconds: 30
             periodSeconds: 5
@@ -43,7 +44,8 @@ spec:
           readinessProbe:
             exec:
               command:
-                - pidof
+                - test
+                - -x
                 - controller
             initialDelaySeconds: 3
             periodSeconds: 5

--- a/data-science-pipelines/base/deployments/ds-pipeline-viewer-crd.yaml
+++ b/data-science-pipelines/base/deployments/ds-pipeline-viewer-crd.yaml
@@ -36,7 +36,8 @@ spec:
           livenessProbe:
             exec:
               command:
-                - pidof
+                - test
+                - -x
                 - controller
             initialDelaySeconds: 30
             periodSeconds: 5
@@ -44,7 +45,8 @@ spec:
           readinessProbe:
             exec:
               command:
-                - pidof
+                - test
+                - -x
                 - controller
             initialDelaySeconds: 3
             periodSeconds: 5

--- a/data-science-pipelines/base/deployments/ds-pipeline-visualizationserver.yaml
+++ b/data-science-pipelines/base/deployments/ds-pipeline-visualizationserver.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       initContainers:
         - name: image-checker
-          image: 'registry.redhat.io/openshift4/ose-cli:v4.8'
+          image: 'quay.io/modh/odh-deployer:v1.15.0-10-rhods'
           command:
             - sh
             - '-c'
@@ -40,7 +40,7 @@ spec:
                 sleep 30
               done
       containers:
-        - image: visualization-server:1.3.1
+        - image: visualization-server
           imagePullPolicy: Always
           name: ds-pipeline-visualizationserver
           ports:

--- a/data-science-pipelines/base/kustomization.yaml
+++ b/data-science-pipelines/base/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 
 resources:
   # Build Configs
-  - ./buildconfigs/vizualization-server.yaml
+  - ./buildconfigs/visualization-server.yaml
 
   # CustomResourceDefinitions
   - ./customresourcedefinitions/viewers.yaml
@@ -16,9 +16,6 @@ resources:
   - ./deployments/ds-pipeline-viewer-crd.yaml
   - ./deployments/ds-pipeline-visualizationserver.yaml
   - ./deployments/ds-pipeline.yaml
-
-  # Image Streams
-  - ./imagestreams/visualization-server.yaml
 
   # Rolebindings
   - ./rolebindings/ds-pipeline-scheduledworkflow-binding.yaml
@@ -48,6 +45,9 @@ resources:
   - ./serviceaccounts/ds-pipeline-visualizationserver.yaml
   - ./serviceaccounts/ds-pipeline.yaml
   - ./serviceaccounts/pipeline-runner.yaml
+
+  # Image Streams
+  - ./imagestreams/visualization-server.yaml
 
   # Services
   - ./services/ds-pipeline-visualizationserver.yaml
@@ -99,19 +99,20 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.ds_pipelines_ui_configuration
+
 configurations:
   - params.yaml
 
 images:
   - name: persistenceagent
-    newName: quay.io/internaldatahub/persistenceagent
-    newTag: 1.1.0
+    newName: quay.io/modh/odh-ml-pipelines-persistenceagent-container
+    newTag: v1.18.0-8
   - name: scheduledworkflow
-    newName: quay.io/internaldatahub/scheduledworkflow
-    newTag: 1.1.0
+    newName: quay.io/modh/odh-ml-pipelines-scheduledworkflow-container
+    newTag: v1.18.0-8
   - name: viewer-crd-controller
-    newName: gcr.io/ml-pipeline/viewer-crd-controller
-    newTag: 1.7.0
+    newName: quay.io/modh/odh-ml-pipelines-viewercontroller-container
+    newTag: v1.18.0-8
   - name: api-server
-    newName: quay.io/internaldatahub/api-server
-    newTag: 1.1.0
+    newName: quay.io/modh/odh-ml-pipelines-api-server-container
+    newTag: v1.18.0-8

--- a/data-science-pipelines/overlays/default-configs/configmaps/ds-pipeline-config.yaml
+++ b/data-science-pipelines/overlays/default-configs/configmaps/ds-pipeline-config.yaml
@@ -5,7 +5,7 @@ data:
   artifact_bucket: mlpipeline
   artifact_endpoint: minio-service:9000
   artifact_endpoint_scheme: http://
-  artifact_image: quay.io/opendatahub/ml-pipelines-artifact-manager:latest
+  artifact_image: quay.io/modh/odh-ml-pipelines-artifact-manager-container:v1.18.0-8
   artifact_script: |-
     #!/usr/bin/env sh
     push_artifact() {

--- a/data-science-pipelines/overlays/ds-pipeline-ui/kustomization.yaml
+++ b/data-science-pipelines/overlays/ds-pipeline-ui/kustomization.yaml
@@ -33,5 +33,5 @@ generatorOptions:
 
 images:
   - name: frontend
-    newName: quay.io/internaldatahub/frontend
-    newTag: 1.1.0
+    newName: quay.io/opendatahub/odh-ml-pipelines-frontend-container
+    newTag: beta-ui

--- a/data-science-pipelines/overlays/integration-odhdashboard/odhapplications/data-science-pipelines-odhapplication.yaml
+++ b/data-science-pipelines/overlays/integration-odhdashboard/odhapplications/data-science-pipelines-odhapplication.yaml
@@ -31,12 +31,12 @@ spec:
   internalRoute: ds-pipeline-ui
   getStartedMarkDown: |-
     # Getting Started With Data Science Pipelines
-    Below are the list of samples that are currently running end to end taking the compiled Tekton yaml and deploying on a Tekton cluster directly. If you are interested more in the larger list of pipelines samples we are testing for whether they can be 'compiled to Tekton' format, please [look at the corresponding status page](https://github.com/opendatahub-io/data-science-pipelines/tree/master/sdk/python/tests/README.md)
-    [DSP Tekton User Guide](https://github.com/opendatahub-io/data-science-pipelines/tree/master/guides/kfp-user-guide) is a guideline for the possible ways to develop and consume Data Science Pipelines. It's recommended to go over at least one of the methods in the user guide before heading into the KFP Tekton Samples.
+    Below are the list of samples that are currently running end to end taking the compiled Tekton yaml and deploying on a Tekton cluster directly. If you are interested more in the larger list of pipelines samples we are testing for whether they can be 'compiled to Tekton' format, please [look at the corresponding status page](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/sdk/python/tests/README.md)
+    [DSP Tekton User Guide](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/guides/kfp-user-guide) is a guideline for the possible ways to develop and consume Data Science Pipelines. It's recommended to go over at least one of the methods in the user guide before heading into the KFP Tekton Samples.
     ## Prerequisites 
     - Install [OpenShift Pipelines Operator](https://docs.openshift.com/container-platform/4.7/cicd/pipelines/installing-pipelines.html). Then connect the cluster to the current shell with `oc` 
     
-    - Install [kfp-tekton](https://github.com/opendatahub-io/data-science-pipelines/tree/master/sdk/README.md) SDK
+    - Install [kfp-tekton](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/sdk/README.md) SDK
 
         ```
         # Set up the python virtual environment
@@ -48,24 +48,24 @@ spec:
         ```
 
     ## Samples
-    - [MNIST End to End example with DSP components](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/e2e-mnist)
+    - [MNIST End to End example with DSP components](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/samples/e2e-mnist)
 
-    - [Hyperparameter tuning using Katib](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/katib)
+    - [Hyperparameter tuning using Katib](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/samples/katib)
 
-    - [Trusted AI Pipeline with AI Fairness 360 and Adversarial Robustness 360 components](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/trusted-ai)
+    - [Trusted AI Pipeline with AI Fairness 360 and Adversarial Robustness 360 components](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/samples/trusted-ai)
 
-    - [Training and Serving Models with Watson Machine Learning](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/watson-train-serve#training-and-serving-models-with-watson-machine-learning)
+    - [Training and Serving Models with Watson Machine Learning](https://github.com/red-hat-data-service/sdata-science-pipelines/tree/master/samples/watson-train-serve#training-and-serving-models-with-watson-machine-learning)
 
-    - [Lightweight python components example](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/lightweight-component)
+    - [Lightweight python components example](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/samples/lightweight-component)
 
-    - [The flip-coin pipeline](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/flip-coin)
+    - [The flip-coin pipeline](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/samples/flip-coin)
 
-    - [Nested pipeline example](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/nested-pipeline)
+    - [Nested pipeline example](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/samples/nested-pipeline)
 
-    - [Pipeline with Nested loops](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/nested-loops)
+    - [Pipeline with Nested loops](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/samples/nested-loops)
 
-    - [Using Tekton Custom Task on DSP](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/tekton-custom-task)
+    - [Using Tekton Custom Task on DSP](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/samples/tekton-custom-task)
 
-    - [The flip-coin pipeline using custom task](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/flip-coin-custom-task)
+    - [The flip-coin pipeline using custom task](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/samples/flip-coin-custom-task)
 
-    - [Retrieve DSP run metadata using Kubernetes downstream API](https://github.com/opendatahub-io/data-science-pipelines/tree/master/samples/k8s-downstream-api)
+    - [Retrieve DSP run metadata using Kubernetes downstream API](https://github.com/red-hat-data-services/data-science-pipelines/tree/master/samples/k8s-downstream-api)

--- a/data-science-pipelines/overlays/integration-odhdashboard/odhquickstarts/data-science-pipelines-odhquickstart.yaml
+++ b/data-science-pipelines/overlays/integration-odhdashboard/odhquickstarts/data-science-pipelines-odhquickstart.yaml
@@ -13,7 +13,7 @@ spec:
   introduction: |-
     ### This quick start shows you how to create a Data Science Pipeline.
     Open Data Hub lets you run Data Science Pipelines in a scalable OpenShift hybrid cloud environment.
-    This quickstart shows you how to compile, create and run a simple example pipeline execution using the Kubeflow Pipelines Python SDK and Data Science Pipelines UI.
+    This quickstart shows you how to compile, create and run a simple example pipeline execution using the Pipelines Python SDK and Data Science Pipelines UI.
   tasks:
     - title: Launch Data Science Pipelines
       description: |-
@@ -33,9 +33,9 @@ spec:
 
     - title: Install Python SDK and compile sample pipeline
       description: |-
-        ### Install the Kubeflow Pipelines Python SDK
-        1. Follow the [Kubeflow Pipelines Tekton Python SDK Installation instructions](https://github.com/opendatahub-io/data-science-pipelines/blob/master/samples/README.md#prerequisites)
-        2. Download, clone or copy the [flip-coin example pipeline](https://github.com/opendatahub-io/data-science-pipelines/blob/master/samples/flip-coin/condition.py)
+        ### Install the Pipelines Python SDK
+        1. Follow the [Pipelines Tekton Python SDK Installation instructions](https://github.com/red-hat-data-services/data-science-pipelines/blob/master/samples/README.md#prerequisites)
+        2. Download, clone or copy the [flip-coin example pipeline](https://github.com/red-hat-data-services/data-science-pipelines/blob/master/samples/flip-coin/condition.py)
         3. Compile the python pipeline defintion into a Tekton YAML:
         ```
         python condition.py
@@ -46,7 +46,7 @@ spec:
           Is there now a `condition.yaml` file in the directory you downloaded `condition.py` from?
         failedTaskHelp: This task is not verified yet. Try the task again.
       summary:
-        success: You have installed the Kubeflow Pipelines Tekton SDK and compiled a sample pipeline definition into a Tekton yaml
+        success: You have installed the Pipelines Tekton SDK and compiled a sample pipeline definition into a Tekton yaml
         failed: Try the steps again.
 
     - title: Create a Pipeline


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): [RHODS-5003](https://issues.redhat.com/browse/RHODS-5003)
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious): 

*Testing Instructions*:

Apply ds-pipelines KfDef found below[1] to RHODS  Cluster (version >=1.18.0)

Test KfDef:
```yaml
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  name: pipelines
  namespace: odh-applications
spec:
  applications:
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: odh-common
      name: odh-common
    - kustomizeConfig:
        overlays:
          - metadata-store-mariadb
          - ds-pipeline-ui
          - object-store-minio
          - integration-odhdashboard
          - default-configs
        repoRef:
          name: manifests
          path: data-science-pipelines
      name: data-science-pipelines
  repos:
    - name: manifests
      uri: "https://github.com/gmfrasca-rhods-dev/odh-manifests/tarball/dsp-modh-images"
```
