### PR TITLE
[UPSTREAM] Add S3 Override Env Vars for DSP API Server

### DIFF
--- a/data-science-pipelines/base/deployments/ds-pipeline.yaml
+++ b/data-science-pipelines/base/deployments/ds-pipeline.yaml
@@ -123,6 +123,34 @@ spec:
               value: ds-pipeline-visualizationserver
             - name: ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT
               value: "8888"
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              value: "$(ARTIFACT_BUCKET)"
+            - name: OBJECTSTORECONFIG_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: accesskey
+                  name: $(artifact_secret_name)
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: secretkey
+                  name: $(artifact_secret_name)
+            - name: OBJECTSTORECONFIG_SECURE
+              valueFrom:
+                secretKeyRef:
+                  key: secure
+                  name: $(artifact_secret_name)
+            - name: MINIO_SERVICE_SERVICE_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: host
+                  name: $(artifact_secret_name)
+            - name: MINIO_SERVICE_SERVICE_PORT
+              valueFrom:
+                secretKeyRef:
+                  key: port
+                  name: $(artifact_secret_name)
+
           image: api-server
           imagePullPolicy: Always
           name: ds-pipeline-api-server

--- a/data-science-pipelines/overlays/default-configs/secrets/mlpipeline-minio-artifact.yaml
+++ b/data-science-pipelines/overlays/default-configs/secrets/mlpipeline-minio-artifact.yaml
@@ -5,5 +5,8 @@ metadata:
     application-crd-id: data-science-pipelines
   name: mlpipeline-minio-artifact
 stringData:
+  host: minio-service
+  port: "9000"
+  secure: "false"
   accesskey: minio     # override this
   secretkey: minio123  # override this


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

Testing Steps: 
1. Deploy DSP on RHODS _without_ the `default_configs` overlay.
2. `kustomize build` the default_configs overlay, and update any s3 metadata in `mlpipeline-minio-artifact` and `ds-pipeline-config` to point to an external s3 server, the `oc apply -f` the files (there should be 4 total files updated)*
3. Got to the DSP UI and run a pipeline
4. Verify artifacts are stored on your external s3 server

*alternatively you can download [this template file](https://github.com/gmfrasca/self-managed-installer/blob/install-dspipelines/manifests/ds-pipelines-config-templates.yaml), then run `oc process -f $template_file [-p param1=param ...] | oc apply -f -` with your desired parameters


