### PR TITLE
Dashboard DSG changes

### DIFF
--- a/odh-dashboard/base/odh-dashboard-crd.yaml
+++ b/odh-dashboard/base/odh-dashboard-crd.yaml
@@ -41,6 +41,8 @@ spec:
                       type: boolean
                     disableUserManagement:
                       type: boolean
+                    disableProjects:
+                      type: boolean
                 groupsConfig:
                   type: object
                   required:

--- a/odh-dashboard/overlays/authentication/deployment.yaml
+++ b/odh-dashboard/overlays/authentication/deployment.yaml
@@ -5,10 +5,12 @@
     args:
       - --https-address=:8443
       - --provider=openshift
-      - --openshift-service-account=rhods-dashboard
       - --upstream=http://localhost:8080
       - --tls-cert=/etc/tls/private/tls.crt
       - --tls-key=/etc/tls/private/tls.key
+      - --client-id=dashboard-oauth-client
+      - --client-secret-file=/etc/oauth/client/secret
+      - --scope=user:full
       - --cookie-secret-file=/etc/oauth/config/cookie_secret
       - --pass-access-token
       - '--openshift-delegate-urls={"/": {"resource": "services", "verb": "get", "name": "rhods-dashboard"}}'
@@ -49,7 +51,9 @@
         name: proxy-tls
       - mountPath: /etc/oauth/config
         name: oauth-config
-        
+      - mountPath: /etc/oauth/client
+        name: oauth-client
+
 - op: add
   path: /spec/template/spec/volumes
   value:
@@ -58,4 +62,7 @@
         secretName: dashboard-proxy-tls
     - name: oauth-config
       secret:
-        secretName: dashboard-oauth-config
+        secretName: dashboard-oauth-config-generated
+    - name: oauth-client
+      secret:
+        secretName: dashboard-oauth-client-generated

--- a/odh-dashboard/overlays/authentication/secret.yaml
+++ b/odh-dashboard/overlays/authentication/secret.yaml
@@ -1,7 +1,22 @@
+---
 apiVersion: v1
 kind: Secret
 metadata:
   name: dashboard-oauth-config
+  annotations:
+    secret-generator.opendatahub.io/name: "cookie_secret"
+    secret-generator.opendatahub.io/type: "oauth"
+    secret-generator.opendatahub.io/complexity: "16"
 type: Opaque
-data:
-  cookie_secret: VGtob01rbFVkRzFJUkdwNlkyTm1jSEZMZVdOQmR6MDk=
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dashboard-oauth-client
+  annotations:
+    secret-generator.opendatahub.io/name: secret
+    secret-generator.opendatahub.io/type: random
+    secret-generator.opendatahub.io/complexity: "32"
+    secret-generator.opendatahub.io/oauth-client-route: rhods-dashboard
+type: Opaque


### PR DESCRIPTION
Create dedicated OAuthclient https://github.com/opendatahub-io/odh-dashboard/pull/658
Generate a random OAuth cookie secret https://github.com/opendatahub-io/odh-dashboard/pull/590/files
Update CRD with disableProjects field

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

Install using live build `quay.io/cfchase/rhods-operator-live-catalog:1.19.0-dashboard-manifests`