### PR TITLE
Add autoscaling permissions to dashboard cluster-role

### DIFF
--- a/odh-dashboard/base/cluster-role.yaml
+++ b/odh-dashboard/base/cluster-role.yaml
@@ -5,6 +5,15 @@ metadata:
 rules:
   - verbs:
       - get
+      - list
+    apiGroups:
+      - machine.openshift.io
+      - autoscaling.openshift.io
+    resources:
+      - machineautoscalers
+      - machinesets
+  - verbs:
+      - get
       - watch
       - list
     apiGroups:


### PR DESCRIPTION
This PR is required for https://github.com/red-hat-data-services/odh-dashboard/commit/2b3cdfda467789fcb604a9f7eefb0252204a5ec4 to work

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-5761, https://issues.redhat.com/browse/RHODS-4617
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
