### PR TITLE
[UPSTREAM] - Adjust DSG Image Puller Permissions

### DIFF
--- a/odh-dashboard/overlays/authentication/fetch-builds-and-images.yaml
+++ b/odh-dashboard/overlays/authentication/fetch-builds-and-images.yaml
@@ -1,0 +1,35 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dsg-cluster-roles
+rules:
+  - apiGroups:
+      - image.openshift.io
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - imagestreams
+  - apiGroups:
+      - build.openshift.io
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - builds
+      - buildconfigs
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: builds-and-images
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dsg-cluster-roles
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/odh-dashboard/overlays/authentication/image-clusterrolebinding.yaml
+++ b/odh-dashboard/overlays/authentication/image-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-image-pullers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-puller
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts

--- a/odh-dashboard/overlays/authentication/kustomization.yaml
+++ b/odh-dashboard/overlays/authentication/kustomization.yaml
@@ -5,6 +5,8 @@ bases:
 resources:
   - clusterrolebinding.yaml
   - secret.yaml
+  - fetch-builds-and-images.yaml
+  - image-clusterrolebinding.yaml
 patchesJson6902:
   - path: deployment.yaml
     target:


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message