### PR TITLE
Federate haproxy metrics for modelmesh monitoring.

### DIFF
--- a/modelmesh-monitoring/base/mesh-monitoring-stack.yaml
+++ b/modelmesh-monitoring/base/mesh-monitoring-stack.yaml
@@ -132,6 +132,42 @@ spec:
       modelmesh-service: modelmesh-serving
 
 ---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: modelmesh-federated-metrics
+  labels:
+    modelmesh-service: modelmesh-serving
+spec:
+  endpoints:
+    - interval: 30s
+      params:
+        'match[]':
+          - '{__name__= "haproxy_backend_http_average_response_latency_milliseconds"}'
+          - '{__name__= "haproxy_backend_http_responses_total"}'
+      honorLabels: true
+      scrapeTimeout: 10s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      bearerTokenSecret:
+        key: ""
+      path: /federate
+      port: web
+      scheme: https
+      tlsConfig:
+        ca: { }
+        cert: { }
+        insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+      - openshift-monitoring
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: openshift-monitoring
+
+---
 apiVersion: v1
 kind: Secret
 type: Opaque


### PR DESCRIPTION
We will need haproxy metrics to measure performance on the inference routes, this pr proposes a servicemonitor to federate these metrics onto the MM prometheus from ocp monitoring prometheus.

To test: 
* Deploy rhods build as described [here](https://github.com/red-hat-data-services/odh-deployer/pull/266#issue-1396632052) 
* Deploy the service monitor
* Navigate to the deployed prometheus instance (localhost:9090 as per instructions in the link above)
* Run queries as described in [this doc](https://docs.google.com/document/d/19QczaxTpbqJr1qOgi9PTlNFm7LSnsOoA7NVdA8ZIc6Q/edit)

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-5440
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
