### PR TITLE
WIP: Exclude modelmesh etcd secret.

### DIFF
--- a/model-mesh/dependencies/quickstart.yaml
+++ b/model-mesh/dependencies/quickstart.yaml
@@ -81,15 +81,3 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: model-serving-etcd
-stringData:
-  etcd_connection: |
-    {
-      "endpoints": "http://etcd:2379",
-      "root_prefix": "modelmesh-serving"
-    }


### PR DESCRIPTION
We want to dynamically generate auth credentials via odh deployer. As such we do not want the odh operator to overwrite the secret that will be updated by the deployer, so we will instead deploy this secret via the deployer and remove it from reconcilliation loop.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-5451

