### PR TITLE
Enable auth in modelmesh etcd

### DIFF
--- a/model-mesh/base/kustomization.yaml
+++ b/model-mesh/base/kustomization.yaml
@@ -6,6 +6,7 @@ commonLabels:
 resources:
 - ../default
 - ../dependencies/quickstart.yaml
+- ../dependencies/scripts
 - ../prometheus
 configMapGenerator:
   - name: mesh-parameters

--- a/model-mesh/dependencies/quickstart.yaml
+++ b/model-mesh/dependencies/quickstart.yaml
@@ -40,6 +40,11 @@ spec:
       labels:
         app: etcd
     spec:
+      volumes:
+        - name: scripts
+          configMap:
+            name: etcd-scripts
+            defaultMode: 0554
       containers:
         - command:
             - etcd
@@ -51,6 +56,15 @@ spec:
             - /tmp/etcd.data
           image: quay.io/modh/etcd-container:3.2.32-rhel7.9-20221017084818
           name: etcd
+          env:
+            - name: ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: etcd-passwords
+                  key: root
+          volumeMounts:
+            - mountPath: /home/scripts
+              name: scripts
           ports:
             - containerPort: 2379
               name: client
@@ -81,3 +95,10 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - /home/scripts/enable_auth.sh ${ROOT_PASSWORD}

--- a/model-mesh/dependencies/quickstart.yaml
+++ b/model-mesh/dependencies/quickstart.yaml
@@ -81,15 +81,3 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: model-serving-etcd
-stringData:
-  etcd_connection: |
-    {
-      "endpoints": "http://etcd:2379",
-      "root_prefix": "modelmesh-serving"
-    }

--- a/model-mesh/dependencies/scripts/enable_auth.sh
+++ b/model-mesh/dependencies/scripts/enable_auth.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e -o pipefail
+export ETCDCTL_API=3
+
+function etcd::availability() {
+    local cmd=$1 # Command whose output we require
+    local interval=$2 # How many seconds to sleep between tries
+    local iterations=$3 # How many times we attempt to run the command
+
+    ii=0
+
+    while [ $ii -le $iterations ]
+    do
+
+        token=$($cmd) && returncode=$? || returncode=$?
+        if [ $returncode -eq 0 ]; then
+            break
+        fi
+
+        ((ii=ii+1))
+        if [ $ii -eq 100 ]; then
+            echo $cmd "did not return a value"
+            exit 1
+        fi
+        sleep $interval
+    done
+    echo $token
+}
+
+cmd='etcdctl --endpoints=http://0.0.0.0:2379 endpoint health'
+
+etcd::availability "${cmd}" 6 10
+
+PASSWORD="${1:-password}"
+
+echo $PASSWORD | etcdctl --endpoints=http://0.0.0.0:2379 user add root --interactive=false
+etcdctl --endpoints=http://0.0.0.0:2379 auth enable

--- a/model-mesh/dependencies/scripts/kustomization.yaml
+++ b/model-mesh/dependencies/scripts/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: etcd-scripts
+    files:
+      - enable_auth.sh


### PR DESCRIPTION
We want to dynamically generate auth credentials via odh deployer. As such we do not want the odh operator to overwrite the secret that will be updated by the deployer, so we will instead deploy this secret via the deployer and remove it from reconcilliation loop.

Part of: 
* https://gitlab.cee.redhat.com/data-hub/rhods-live-builder/-/merge_requests/100
* https://github.com/red-hat-data-services/odh-deployer/pull/287


- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-5451
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

Relevant docs: 
* https://etcd.io/docs/v3.2/op-guide/authentication/
