### PR TITLE
1.19 - Set dashboard cookie expiration to less than OpenShift default

### DIFF
--- a/odh-dashboard/overlays/authentication/deployment.yaml
+++ b/odh-dashboard/overlays/authentication/deployment.yaml
@@ -10,6 +10,7 @@
       - --tls-key=/etc/tls/private/tls.key
       - --client-id=dashboard-oauth-client
       - --client-secret-file=/etc/oauth/client/secret
+      - --cookie-expire=23h0m0s
       - --scope=user:full
       - --cookie-secret-file=/etc/oauth/config/cookie_secret
       - --pass-access-token


### PR DESCRIPTION
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-6061
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
