### PR TITLE
Update Permission for Cluster proxy

### DIFF
--- a/odh-notebook-controller/odh-notebook-controller/rbac/role.yaml
+++ b/odh-notebook-controller/odh-notebook-controller/rbac/role.yaml
@@ -11,6 +11,7 @@ rules:
   - secrets
   - serviceaccounts
   - services
+  - configmaps
   verbs:
   - create
   - get
@@ -49,4 +50,12 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+  - list
   - watch


### PR DESCRIPTION


- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s): https://issues.redhat.com/browse/RHODS-5811
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
