### PR TITLE
Add authdelegator CRB for PrometheusSA

### DIFF
--- a/modelmesh-monitoring/base/prometheus/rbac/clusterrole_prometheus_token_access.yaml
+++ b/modelmesh-monitoring/base/prometheus/rbac/clusterrole_prometheus_token_access.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus-token-access
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-custom
+    namespace: redhat-ods-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'system:auth-delegator'

--- a/modelmesh-monitoring/base/prometheus/rbac/kustomization.yaml
+++ b/modelmesh-monitoring/base/prometheus/rbac/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - clusterrole_rhods-namespace-read.yaml
 - clusterrolebinding_rhods-model-monitoring.yaml
 - clusterrole_prometheus-k8s.yaml
+- clusterrole_prometheus_token_access.yaml


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-6908
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)


Testing Instructions: 
Livebuild image: http://quay.io/vedantm/rhods-operator-live-catalog:1.23.0-6908 
- Install RHODS using livebuild image linked above
- Create an InferenceService (I used https://github.com/opendatahub-io/modelmesh-serving/tree/main/quickstart) 
- Make a GET call on `$HOST_NAME/api/v1/query?query=sum(haproxy_backend_http_responses_total{exported_namespace="$NAMESPACE", route="$MODEL_ROUTE_NAME"})` where `$HOST_NAME` is the route for `rhods-model-monitoring`. Provided the authoriation bearer token to the call. 
- GET call result should be a metric value instead of a login page for rhods