### PR TITLE
Add Data Science Pipelines Operator.

### DIFF
--- a/data-science-pipelines-operator/OWNERS
+++ b/data-science-pipelines-operator/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+  - anishasthana
+  - gmfrasca
+  - gregsheremeta
+  - HumairAK
+  - rimolive
+reviewers:
+  - anishasthana
+  - DharmitD
+  - gmfrasca
+  - gregsheremeta
+  - harshad16
+  - HumairAK
+  - rimolive

--- a/data-science-pipelines-operator/README.md
+++ b/data-science-pipelines-operator/README.md
@@ -1,0 +1,103 @@
+# Data Science Pipelines Operator
+
+The Data Science Pipelines Operator (DSPO) is an OpenShift Operator that is used to deploy single namespace scoped 
+Data Science Pipeline stacks onto individual OCP namespaces.
+
+# Table of Contents
+
+1. [Quickstart](#quickstart)
+   1. [Pre-requisites](#pre-requisites)
+   2. [Deploy the Operator via RHODS](#deploy-the-operator-via-rhods)
+4. [Cleanup RHODS Installation](#cleanup-rhods-installation)
+
+# Quickstart
+
+To get started you will first need to satisfy the following pre-requisites:
+
+## Pre-requisites
+1. An OpenShift cluster that is 4.9 or higher.
+2. You will need to be logged into this cluster as [cluster admin] via [oc client].
+3. The OpenShift Cluster must have OpenShift Pipelines 1.7.2 or higher installed. Instructions [here][OCP Pipelines Operator].
+4. The RHODS needs to be installed.
+
+## Deploy the Operator via RHODS
+
+On a cluster with RHODS installed, create a namespace where you would like to install DSPO: 
+
+```bash
+DSPO_NS=redhat-ods-applications
+oc new-project ${DSPO_NS}
+```
+
+Then deploy the following `KfDef` into the namespace created above:
+
+```bash
+cat <<EOF | oc apply -f -
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+   name: data-science-pipelines-operator
+   namespace: ${DSPO_NS}
+spec:
+   applications:
+      - kustomizeConfig:
+           repoRef:
+              name: manifests
+              path: data-science-pipelines-operator/
+        name: data-science-pipelines-operator
+   repos:
+      - name: manifests
+        uri: "https://github.com/red-hat-data-services/odh-manifests/tarball/master"
+EOF
+```
+
+Confirm the pods are successfully deployed and reach running state:
+
+```bash
+oc get pods -n ${DSPO_NS}
+```
+
+## Deploy DSP Instance 
+
+Once all pods are ready, we can deploy an RHODS Data Science Pipelines stack by deploying a `DSPA` custom resource.
+
+First let's create a namespace where we want to deploy Data Science Pipelines: 
+
+```bash
+DSPA_NS=data-science-project
+oc new-project ${DSPA_NS}
+```
+
+Then deploy a DSPA instance in this namespace:
+
+```bash
+cat <<EOF | oc apply -f -
+apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
+kind: DataSciencePipelinesApplication
+metadata:
+  name: sample
+  namespace: ${DSPA_NS}
+spec:
+  objectStorage:
+    minio:
+      image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
+  mlpipelineUI:
+    image: 'quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui'
+EOF
+```
+
+For more detailed instructions on how to interact with this stack, see the docs [here][dspo-repo].
+
+## Cleanup RHODS Installation
+
+To uninstall DSPO via RHODS run the following:
+
+```bash
+KFDEF_NAME=data-science-pipelines-operator
+oc delete kfdef ${KFDEF_NAME} -n ${DSPO_NS}
+```
+
+[cluster admin]: https://docs.openshift.com/container-platform/4.12/authentication/using-rbac.html#creating-cluster-admin_using-rbac
+[oc client]: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux.tar.gz
+[OCP Pipelines Operator]: https://docs.openshift.com/container-platform/4.12/cicd/pipelines/installing-pipelines.html#op-installing-pipelines-operator-in-web-console_installing-pipelines
+[dspo-repo]: https://github.com/opendatahub-io/data-science-pipelines-operator#using-a-datasciencepipelinesapplication

--- a/data-science-pipelines-operator/base/kustomization.yaml
+++ b/data-science-pipelines-operator/base/kustomization.yaml
@@ -1,0 +1,82 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: odh-applications
+namePrefix: data-science-pipelines-operator-
+resources:
+  - ../crd
+  - ../rbac
+  - ../manager
+  - ../prometheus
+  - ../configmaps
+
+# Parameterize images via KfDef in ODH
+configMapGenerator:
+  - name: dspo-parameters
+    envs:
+      - params.env
+vars:
+  - name: IMAGES_APISERVER
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_APISERVER
+  - name: IMAGES_ARTIFACT
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_ARTIFACT
+  - name: IMAGES_PERSISTENTAGENT
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_PERSISTENTAGENT
+  - name: IMAGES_SCHEDULEDWORKFLOW
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_SCHEDULEDWORKFLOW
+  - name: IMAGES_VIEWERCRD
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_VIEWERCRD
+  - name: IMAGES_CACHE
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_CACHE
+  - name: IMAGES_MOVERESULTSIMAGE
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_MOVERESULTSIMAGE
+  - name: IMAGES_MARIADB
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_MARIADB
+  - name: IMAGES_DSPO
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_DSPO
+configurations:
+  - params.yaml

--- a/data-science-pipelines-operator/base/params.env
+++ b/data-science-pipelines-operator/base/params.env
@@ -1,0 +1,9 @@
+IMAGES_APISERVER=registry.redhat.io/rhods/odh-ml-pipelines-api-server-rhel8:latest
+IMAGES_ARTIFACT=registry.redhat.io/rhods/odh-ml-pipelines-artifact-manager-rhel8:latest
+IMAGES_PERSISTENTAGENT=registry.redhat.io/rhods/odh-ml-pipelines-persistenceagent-rhel8:latest
+IMAGES_SCHEDULEDWORKFLOW=registry.redhat.io/rhods/odh-ml-pipelines-scheduledworkflow-rhel8:latest
+IMAGES_VIEWERCRD=registry.redhat.io/rhods/odh-ml-pipelines-viewercontroller-rhel8:latest
+IMAGES_CACHE=registry.redhat.io/rhods/odh-ml-pipelines-cache-rhel8:latest
+IMAGES_MOVERESULTSIMAGE=registry.redhat.io/ubi8/ubi-micro:8.7
+IMAGES_MARIADB=registry.redhat.io/rhel8/mariadb-103:1
+IMAGES_DSPO=quay.io/opendatahub/data-science-pipelines-operator:latest

--- a/data-science-pipelines-operator/base/params.yaml
+++ b/data-science-pipelines-operator/base/params.yaml
@@ -1,0 +1,7 @@
+varReference:
+- path: data
+  kind: ConfigMap
+- path: spec/template/spec/containers/env/value
+  kind: Deployment
+- path: spec/template/spec/containers/image
+  kind: Deployment

--- a/data-science-pipelines-operator/configmaps/files/config.yaml
+++ b/data-science-pipelines-operator/configmaps/files/config.yaml
@@ -1,0 +1,9 @@
+Images:
+  ApiServer: $(IMAGES_APISERVER)
+  Artifact: $(IMAGES_ARTIFACT)
+  PersistentAgent: $(IMAGES_PERSISTENTAGENT)
+  ScheduledWorkflow: $(IMAGES_SCHEDULEDWORKFLOW)
+  ViewerCRD: $(IMAGES_VIEWERCRD)
+  Cache: $(IMAGES_CACHE)
+  MoveResultsImage: $(IMAGES_MOVERESULTSIMAGE)
+  MariaDB: $(IMAGES_MARIADB)

--- a/data-science-pipelines-operator/configmaps/kustomization.yaml
+++ b/data-science-pipelines-operator/configmaps/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - name: dspo-config
+    files:
+      - files/config.yaml

--- a/data-science-pipelines-operator/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/data-science-pipelines-operator/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -1,0 +1,616 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: datasciencepipelinesapplications.datasciencepipelinesapplications.opendatahub.io
+spec:
+  group: datasciencepipelinesapplications.opendatahub.io
+  names:
+    kind: DataSciencePipelinesApplication
+    listKind: DataSciencePipelinesApplicationList
+    plural: datasciencepipelinesapplications
+    shortNames:
+    - dspa
+    singular: datasciencepipelinesapplication
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              apiServer:
+                default:
+                  deploy: true
+                description: APIService specifies the Kubeflow Apiserver configurations
+                properties:
+                  applyTektonCustomResource:
+                    default: true
+                    type: boolean
+                  archiveLogs:
+                    default: false
+                    type: boolean
+                  artifactImage:
+                    type: string
+                  artifactScriptConfigMap:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  autoUpdatePipelineDefaultVersion:
+                    default: true
+                    type: boolean
+                  cacheImage:
+                    type: string
+                  collectMetrics:
+                    default: true
+                    type: boolean
+                  dbConfigConMaxLifetimeSec:
+                    default: 120
+                    type: integer
+                  deploy:
+                    default: true
+                    type: boolean
+                  enableOauth:
+                    default: true
+                    type: boolean
+                  image:
+                    type: string
+                  injectDefaultScript:
+                    default: true
+                    type: boolean
+                  moveResultsImage:
+                    type: string
+                  resources:
+                    description: ResourceRequirements structures compute resource
+                      requirements. Replaces ResourceRequirements from corev1 which
+                      also includes optional storage field. We handle storage field
+                      separately, and should not include it as a subfield for Resources.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  stripEOF:
+                    default: true
+                    type: boolean
+                  terminateStatus:
+                    default: Cancelled
+                    type: string
+                  trackArtifacts:
+                    default: true
+                    type: boolean
+                type: object
+              database:
+                default:
+                  mariaDB:
+                    deploy: true
+                properties:
+                  externalDB:
+                    properties:
+                      host:
+                        type: string
+                      passwordSecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      pipelineDBName:
+                        type: string
+                      port:
+                        type: string
+                      username:
+                        type: string
+                    required:
+                    - host
+                    - passwordSecret
+                    - pipelineDBName
+                    - port
+                    - username
+                    type: object
+                  mariaDB:
+                    properties:
+                      deploy:
+                        default: true
+                        type: boolean
+                      image:
+                        type: string
+                      passwordSecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      pipelineDBName:
+                        default: mlpipeline
+                        type: string
+                      pvcSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 10Gi
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      resources:
+                        description: ResourceRequirements structures compute resource
+                          requirements. Replaces ResourceRequirements from corev1
+                          which also includes optional storage field. We handle storage
+                          field separately, and should not include it as a subfield
+                          for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      username:
+                        default: mlpipeline
+                        type: string
+                    type: object
+                type: object
+              mlpipelineUI:
+                properties:
+                  configMap:
+                    type: string
+                  deploy:
+                    default: true
+                    type: boolean
+                  image:
+                    type: string
+                  resources:
+                    description: ResourceRequirements structures compute resource
+                      requirements. Replaces ResourceRequirements from corev1 which
+                      also includes optional storage field. We handle storage field
+                      separately, and should not include it as a subfield for Resources.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                required:
+                - image
+                type: object
+              objectStorage:
+                properties:
+                  externalStorage:
+                    properties:
+                      bucket:
+                        type: string
+                      host:
+                        type: string
+                      port:
+                        type: string
+                      s3CredentialsSecret:
+                        properties:
+                          accessKey:
+                            description: The "Keys" in the k8sSecret key/value pairs.
+                              Not to be confused with the values.
+                            type: string
+                          secretKey:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - accessKey
+                        - secretKey
+                        - secretName
+                        type: object
+                      scheme:
+                        type: string
+                    required:
+                    - bucket
+                    - host
+                    - port
+                    - s3CredentialsSecret
+                    - scheme
+                    type: object
+                  minio:
+                    properties:
+                      bucket:
+                        default: mlpipeline
+                        type: string
+                      deploy:
+                        default: true
+                        type: boolean
+                      image:
+                        type: string
+                      pvcSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 10Gi
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      resources:
+                        description: ResourceRequirements structures compute resource
+                          requirements. Replaces ResourceRequirements from corev1
+                          which also includes optional storage field. We handle storage
+                          field separately, and should not include it as a subfield
+                          for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      s3CredentialsSecret:
+                        properties:
+                          accessKey:
+                            description: The "Keys" in the k8sSecret key/value pairs.
+                              Not to be confused with the values.
+                            type: string
+                          secretKey:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - accessKey
+                        - secretKey
+                        - secretName
+                        type: object
+                    required:
+                    - image
+                    type: object
+                type: object
+              persistenceAgent:
+                default:
+                  deploy: true
+                properties:
+                  deploy:
+                    default: true
+                    type: boolean
+                  image:
+                    type: string
+                  numWorkers:
+                    default: 2
+                    type: integer
+                  resources:
+                    description: ResourceRequirements structures compute resource
+                      requirements. Replaces ResourceRequirements from corev1 which
+                      also includes optional storage field. We handle storage field
+                      separately, and should not include it as a subfield for Resources.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              scheduledWorkflow:
+                default:
+                  deploy: true
+                properties:
+                  cronScheduleTimezone:
+                    default: UTC
+                    type: string
+                  deploy:
+                    default: true
+                    type: boolean
+                  image:
+                    type: string
+                  resources:
+                    description: ResourceRequirements structures compute resource
+                      requirements. Replaces ResourceRequirements from corev1 which
+                      also includes optional storage field. We handle storage field
+                      separately, and should not include it as a subfield for Resources.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              viewerCRD:
+                default:
+                  deploy: false
+                properties:
+                  deploy:
+                    default: false
+                    type: boolean
+                  image:
+                    type: string
+                  maxNumViewer:
+                    default: 50
+                    type: integer
+                  resources:
+                    description: ResourceRequirements structures compute resource
+                      requirements. Replaces ResourceRequirements from corev1 which
+                      also includes optional storage field. We handle storage field
+                      separately, and should not include it as a subfield for Resources.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+            required:
+            - objectStorage
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/data-science-pipelines-operator/crd/bases/scheduledworkflows.yaml
+++ b/data-science-pipelines-operator/crd/bases/scheduledworkflows.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    application-crd-id: data-science-pipelines
+    kubeflow/crd-install: "true"
+  name: scheduledworkflows.kubeflow.org
+spec:
+  conversion:
+    strategy: None
+  group: kubeflow.org
+  names:
+    kind: ScheduledWorkflow
+    listKind: ScheduledWorkflowList
+    plural: scheduledworkflows
+    shortNames:
+    - swf
+    singular: scheduledworkflow
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        - status
+        type: object
+    served: true
+    storage: true

--- a/data-science-pipelines-operator/crd/bases/viewers.yaml
+++ b/data-science-pipelines-operator/crd/bases/viewers.yaml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    application-crd-id: data-science-pipelines
+    kubeflow/crd-install: "true"
+  name: viewers.kubeflow.org
+spec:
+  conversion:
+    strategy: None
+  group: kubeflow.org
+  names:
+    kind: Viewer
+    listKind: ViewerList
+    plural: viewers
+    shortNames:
+    - vi
+    singular: viewer
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/data-science-pipelines-operator/crd/external/route.openshift.io_routes.yaml
+++ b/data-science-pipelines-operator/crd/external/route.openshift.io_routes.yaml
@@ -1,0 +1,254 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: routes.route.openshift.io
+spec:
+  group: route.openshift.io
+  names:
+    kind: Route
+    listKind: RouteList
+    plural: routes
+    singular: route
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "A route allows developers to expose services through an HTTP(S)
+          aware load balancing and proxy layer via a public DNS entry. The route may
+          further specify TLS options and a certificate, or specify a public CNAME
+          that the router should also accept for HTTP and HTTPS traffic. An administrator
+          typically configures their router to be visible outside the cluster firewall,
+          and may also add additional security, caching, or traffic controls on the
+          service content. Routers usually talk directly to the service endpoints.
+          \n Once a route is created, the `host` field may not be changed. Generally,
+          routers use the oldest route with a given host when resolving conflicts.
+          \n Routers are subject to additional customization and may support additional
+          controls via the annotations field. \n Because administrators may configure
+          multiple routers, the route status field is used to return information to
+          clients about the names and states of the route under each router. If a
+          client chooses a duplicate name, for instance, the route status conditions
+          are used to indicate the route cannot be chosen."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the route
+            properties:
+              alternateBackends:
+                description: alternateBackends allows up to 3 additional backends
+                  to be assigned to the route. Only the Service kind is allowed, and
+                  it will be defaulted to Service. Use the weight field in RouteTargetReference
+                  object to specify relative preference.
+                items:
+                  description: RouteTargetReference specifies the target that resolve
+                    into endpoints. Only the 'Service' kind is allowed. Use 'weight'
+                    field to emphasize one over others.
+                  properties:
+                    kind:
+                      description: The kind of target that the route is referring
+                        to. Currently, only 'Service' is allowed
+                      type: string
+                    name:
+                      description: name of the service/target that is being referred
+                        to. e.g. name of the service
+                      type: string
+                    weight:
+                      description: weight as an integer between 0 and 256, default
+                        1, that specifies the target's relative weight against other
+                        target reference objects. 0 suppresses requests to this backend.
+                      format: int32
+                      type: integer
+                  required:
+                  - kind
+                  - name
+                  - weight
+                  type: object
+                type: array
+              host:
+                description: host is an alias/DNS that points to the service. Optional.
+                  If not specified a route name will typically be automatically chosen.
+                  Must follow DNS952 subdomain conventions.
+                type: string
+              path:
+                description: Path that the router watches for, to route traffic for
+                  to the service. Optional
+                type: string
+              port:
+                description: If specified, the port to be used by the router. Most
+                  routers will use all endpoints exposed by the service by default
+                  - set this value to instruct routers which port to use.
+                properties:
+                  targetPort:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: The target port on pods selected by the service this
+                      route points to. If this is a string, it will be looked up as
+                      a named port in the target endpoints port list. Required
+                    x-kubernetes-int-or-string: true
+                required:
+                - targetPort
+                type: object
+              tls:
+                description: The tls field provides the ability to configure certificates
+                  and termination for the route.
+                properties:
+                  caCertificate:
+                    description: caCertificate provides the cert authority certificate
+                      contents
+                    type: string
+                  certificate:
+                    description: certificate provides certificate contents
+                    type: string
+                  destinationCACertificate:
+                    description: destinationCACertificate provides the contents of
+                      the ca certificate of the final destination.  When using reencrypt
+                      termination this file should be provided in order to have routers
+                      use it for health checks on the secure connection. If this field
+                      is not specified, the router may provide its own destination
+                      CA and perform hostname validation using the short service name
+                      (service.namespace.svc), which allows infrastructure generated
+                      certificates to automatically verify.
+                    type: string
+                  insecureEdgeTerminationPolicy:
+                    description: "insecureEdgeTerminationPolicy indicates the desired
+                      behavior for insecure connections to a route. While each router
+                      may make its own decisions on which ports to expose, this is
+                      normally port 80. \n * Allow - traffic is sent to the server
+                      on the insecure port (default) * Disable - no traffic is allowed
+                      on the insecure port. * Redirect - clients are redirected to
+                      the secure port."
+                    type: string
+                  key:
+                    description: key provides key file contents
+                    type: string
+                  termination:
+                    description: termination indicates termination type.
+                    type: string
+                required:
+                - termination
+                type: object
+              to:
+                description: to is an object the route should use as the primary backend.
+                  Only the Service kind is allowed, and it will be defaulted to Service.
+                  If the weight field (0-256 default 1) is set to zero, no traffic
+                  will be sent to this backend.
+                properties:
+                  kind:
+                    description: The kind of target that the route is referring to.
+                      Currently, only 'Service' is allowed
+                    type: string
+                  name:
+                    description: name of the service/target that is being referred
+                      to. e.g. name of the service
+                    type: string
+                  weight:
+                    description: weight as an integer between 0 and 256, default 1,
+                      that specifies the target's relative weight against other target
+                      reference objects. 0 suppresses requests to this backend.
+                    format: int32
+                    type: integer
+                required:
+                - kind
+                - name
+                - weight
+                type: object
+              wildcardPolicy:
+                description: Wildcard policy if any for the route. Currently only
+                  'Subdomain' or 'None' is allowed.
+                type: string
+            required:
+            - to
+            type: object
+          status:
+            description: status is the current state of the route
+            properties:
+              ingress:
+                description: ingress describes the places where the route may be exposed.
+                  The list of ingress points may contain duplicate Host or RouterName
+                  values. Routes are considered live once they are `Ready`
+                items:
+                  description: RouteIngress holds information about the places where
+                    a route is exposed.
+                  properties:
+                    conditions:
+                      description: Conditions is the state of the route, may be empty.
+                      items:
+                        description: RouteIngressCondition contains details for the
+                          current condition of this route on a particular router.
+                        properties:
+                          lastTransitionTime:
+                            description: RFC 3339 date and time when this condition
+                              last transitioned
+                            format: date-time
+                            type: string
+                          message:
+                            description: Human readable message indicating details
+                              about last transition.
+                            type: string
+                          reason:
+                            description: (brief) reason for the condition's last transition,
+                              and is usually a machine and human readable constant
+                            type: string
+                          status:
+                            description: Status is the status of the condition. Can
+                              be True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the condition. Currently
+                              only Ready.
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    host:
+                      description: Host is the host string under which the route is
+                        exposed; this value is required
+                      type: string
+                    routerCanonicalHostname:
+                      description: CanonicalHostname is the external host name for
+                        the router that can be used as a CNAME for the host requested
+                        for this route. This value is optional and may not be set
+                        in all cases.
+                      type: string
+                    routerName:
+                      description: Name is a name chosen by the router to identify
+                        itself; this value is required
+                      type: string
+                    wildcardPolicy:
+                      description: Wildcard policy is the wildcard policy that was
+                        allowed where this route is exposed.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - ingress
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/data-science-pipelines-operator/crd/kustomization.yaml
+++ b/data-science-pipelines-operator/crd/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+# +kubebuilder:scaffold:crdkustomizeresource
+- bases/scheduledworkflows.yaml
+- bases/viewers.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/data-science-pipelines-operator/crd/kustomizeconfig.yaml
+++ b/data-science-pipelines-operator/crd/kustomizeconfig.yaml
@@ -1,0 +1,19 @@
+# This file is for teaching kustomize how to substitute name and namespace reference in CRD
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: CustomResourceDefinition
+    version: v1
+    group: apiextensions.k8s.io
+    path: spec/conversion/webhook/clientConfig/service/name
+
+namespace:
+- kind: CustomResourceDefinition
+  version: v1
+  group: apiextensions.k8s.io
+  path: spec/conversion/webhook/clientConfig/service/namespace
+  create: false
+
+varReference:
+- path: metadata/annotations

--- a/data-science-pipelines-operator/manager/kustomization.yaml
+++ b/data-science-pipelines-operator/manager/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- manager.yaml
+- manager-service.yaml

--- a/data-science-pipelines-operator/manager/manager-service.yaml
+++ b/data-science-pipelines-operator/manager/manager-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: data-science-pipelines-operator
+  labels:
+    control-plane: controller-manager
+spec:
+  ports:
+    - name: metrics
+      port: 8080
+  selector:
+    control-plane: controller-manager

--- a/data-science-pipelines-operator/manager/manager.yaml
+++ b/data-science-pipelines-operator/manager/manager.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: datasciencepipelinesapplications-controller
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: data-science-pipelines-operator
+    app.kubernetes.io/part-of: data-science-pipelines-operator
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 3
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      volumes:
+        - name: config
+          configMap:
+            name: dspo-config
+      containers:
+      - command:
+        - /manager
+        args:
+        - --leader-elect
+        - --config
+        - /home/config
+        image: $(IMAGES_DSPO)
+        name: manager
+        env:
+          # Env vars are prioritized over --config
+          - name: IMAGES_APISERVER
+            value: $(IMAGES_APISERVER)
+          - name: IMAGES_ARTIFACT
+            value: $(IMAGES_ARTIFACT)
+          - name: IMAGES_PERSISTENTAGENT
+            value: $(IMAGES_PERSISTENTAGENT)
+          - name: IMAGES_SCHEDULEDWORKFLOW
+            value: $(IMAGES_SCHEDULEDWORKFLOW)
+          - name: IMAGES_VIEWERCRD
+            value: $(IMAGES_VIEWERCRD)
+          - name: IMAGES_CACHE
+            value: $(IMAGES_CACHE)
+          - name: IMAGES_MOVERESULTSIMAGE
+            value: $(IMAGES_MOVERESULTSIMAGE)
+          - name: IMAGES_MARIADB
+            value: $(IMAGES_MARIADB)
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 1
+            memory: 2Gi
+          requests:
+            cpu: 1
+            memory: 2Gi
+        volumeMounts:
+          - mountPath: /home/config
+            name: config
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10

--- a/data-science-pipelines-operator/manifests/kustomization.yaml
+++ b/data-science-pipelines-operator/manifests/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- bases/data-science-pipelines-operator.clusterserviceversion.yaml
+- ../default

--- a/data-science-pipelines-operator/prometheus/kustomization.yaml
+++ b/data-science-pipelines-operator/prometheus/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- monitor.yaml

--- a/data-science-pipelines-operator/prometheus/monitor.yaml
+++ b/data-science-pipelines-operator/prometheus/monitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: data-science-pipelines-operator-monitor
+  namespace: data-science-pipelines-operator
+spec:
+  endpoints:
+    - path: /metrics
+      port: metrics
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/data-science-pipelines-operator/rbac/kustomization.yaml
+++ b/data-science-pipelines-operator/rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- service_account.yaml
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml

--- a/data-science-pipelines-operator/rbac/leader_election_role.yaml
+++ b/data-science-pipelines-operator/rbac/leader_election_role.yaml
@@ -1,0 +1,43 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: data-science-pipelines-operator
+    app.kubernetes.io/part-of: data-science-pipelines-operator
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/data-science-pipelines-operator/rbac/leader_election_role_binding.yaml
+++ b/data-science-pipelines-operator/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: data-science-pipelines-operator
+    app.kubernetes.io/part-of: data-science-pipelines-operator
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: datasciencepipelinesapplications-controller

--- a/data-science-pipelines-operator/rbac/role.yaml
+++ b/data-science-pipelines-operator/rbac/role.yaml
@@ -1,0 +1,219 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - deployments
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  - ""
+  - extensions
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - '*'
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - '*'
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - persistentvolumeclaims
+  - persistentvolumes
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  - pods/log
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - custom.tekton.dev
+  resources:
+  - pipelineloops
+  verbs:
+  - '*'
+- apiGroups:
+  - datasciencepipelinesapplications.opendatahub.io
+  resources:
+  - datasciencepipelinesapplications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - datasciencepipelinesapplications.opendatahub.io
+  resources:
+  - datasciencepipelinesapplications/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - datasciencepipelinesapplications.opendatahub.io
+  resources:
+  - datasciencepipelinesapplications/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreamtags
+  verbs:
+  - get
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - machinelearning.seldon.io
+  resources:
+  - seldondeployments
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - tekton.dev
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/data-science-pipelines-operator/rbac/role_binding.yaml
+++ b/data-science-pipelines-operator/rbac/role_binding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: data-science-pipelines-operator
+    app.kubernetes.io/part-of: data-science-pipelines-operator
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: datasciencepipelinesapplications-controller

--- a/data-science-pipelines-operator/rbac/service_account.yaml
+++ b/data-science-pipelines-operator/rbac/service_account.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: data-science-pipelines-operator
+    app.kubernetes.io/part-of: data-science-pipelines-operator
+  name: controller-manager
+  namespace: datasciencepipelinesapplications-controller


### PR DESCRIPTION
**Depends on: https://github.com/opendatahub-io/odh-manifests/pull/729**


This change adds the Data Science Pipelines Operator to ODH-Manifest so that the RHODS Operator can be used to deploy DSPO via KfDef that points to odh-manifests.

A README is included on how users can use RHODS to deploy DSPO via kfdef.

The manifests are entirely identical to those provided in the DSPO app repo. The README has been modified to be contextually relevant to RHODS.

Additional docs can be found in the original DSPO app repo.

## Testing Instructions: 

* Deploy RHODS-Operator

* Deploy the following kfdef: 

```yaml
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
   name: data-science-pipelines-operator
   namespace: redhat-ods-applications
spec:
   applications:
      - kustomizeConfig:
           repoRef:
              name: manifests
              path: data-science-pipelines-operator/
        name: data-science-pipelines-operator
   repos:
      - name: manifests
        uri: "https://github.com/HumairAK/odh-manifests/tarball/rhods-odh-add-dspo"
```

Create a DSPA CR by following these few steps [here](https://github.com/red-hat-data-services/odh-manifests/pull/317/files#diff-68574da33cb06549515dac6d93de645a24da50f2531a2cd22673ce2077414699R60-R90)

Gif is provided [here](https://github.com/opendatahub-io/odh-manifests/pull/729) that illustrates this for ODH but the steps are the same for RHODs, just with the RHODs operator instead.

## Checklist

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s):
    * [RHODS-6926](https://issues.redhat.com/browse/RHODS-6926)
    * Related: [RHODS-7151](https://issues.redhat.com/browse/RHODS-7151)
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
