### PR TITLE
[rhods-1.24] Update resources for dashboard oauth-proxy

### DIFF
--- a/odh-dashboard/overlays/authentication/deployment.yaml
+++ b/odh-dashboard/overlays/authentication/deployment.yaml
@@ -42,11 +42,11 @@
       failureThreshold: 3
     resources:
       limits:
-        cpu: 100m
-        memory: 256Mi
+        cpu: 1000m
+        memory: 2Gi
       requests:
-        cpu: 100m
-        memory: 256Mi
+        cpu: 500m
+        memory: 1Gi
     volumeMounts:
       - mountPath: /etc/tls/private
         name: proxy-tls


### PR DESCRIPTION
(cherry picked from commit 63b00b674d18e9b90518f12cbddc981442b4e394)

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s): https://issues.redhat.com/browse/RHODS-6447
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
