### PR TITLE
Update RHODS ootb image streams: with N & N-1 versions and TrustyAi 

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/jupyter/datascience/ubi8-python-3.8"
+    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/jupyter/datascience"
     opendatahub.io/notebook-image-name: "Standard Data Science"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks"
     opendatahub.io/notebook-image-order: "20"
@@ -13,13 +13,25 @@ spec:
   lookupPolicy:
     local: true
   tags:
+  # N Version of the image (v2-2023a-20230322-9f24e3e)
+  - annotations:
+      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
+      openshift.io/imported-from: quay.io/modh/odh-generic-data-science-notebook
+      opendatahub.io/workbench-image-recommended: 'true'
+    from:
+      kind: DockerImage
+      name: quay.io/modh/odh-generic-data-science-notebook@sha256:46dbee9764ae96d95fb5719446226bf0b86ec1e8cc695ac12df575a352d79f8f
+    name: "py3.9-v2"
+    referencePolicy:
+      type: Source
+  # N-1 Version of the image
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
       openshift.io/imported-from: quay.io/modh/odh-generic-data-science-notebook
     from:
       kind: DockerImage
-      # if you change the image tag, change the "-N" on the tag name immediately below
       name: quay.io/modh/odh-generic-data-science-notebook@sha256:ebb5613e6b53dc4e8efcfe3878b4cd10ccb77c67d12c00d2b8c9d41aeffd7df5
     name: "py3.8-v1"
     referencePolicy:

--- a/jupyterhub/notebook-images/overlays/additional/kustomization.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - minimal-gpu-notebook-imagestream.yaml
 - pytorch-notebook-imagestream.yaml
 - tensorflow-notebook-imagestream.yaml
+- trustyai-notebook-imagestream.yaml
 
 commonLabels:
   opendatahub.io/component: "true"

--- a/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/jupyter/minimal/ubi8-python-3.8"
+    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/jupyter/minimal"
     opendatahub.io/notebook-image-name: "CUDA"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and minimal dependency set to start experimenting with Jupyter environment."
     opendatahub.io/notebook-image-order: "30"
@@ -13,6 +13,19 @@ spec:
   lookupPolicy:
     local: true
   tags:
+  # N Version of the image (2023a-20230322-9f24e3e)
+  - annotations:
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.5"},{"name":"Notebook","version":"6.5"}]'
+        openshift.io/imported-from: quay.io/modh/cuda-notebooks
+        opendatahub.io/workbench-image-recommended: 'true'
+    from:
+      kind: DockerImage
+      name: quay.io/modh/cuda-notebooks@sha256:a6080e64d9b70683d8f19334d85e5df7d574f260e2923568e1c5d955d2a8bdc5
+    name: "py3.9-v2-cuda-11.8.0"
+    referencePolicy:
+      type: Local
+  # N-1 Version of the image
   - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.2"},{"name":"Notebook","version":"6.4"}]'
@@ -20,6 +33,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/modh/cuda-notebooks@sha256:348fa993347f86d1e0913853fb726c584ae8b5181152f0430967d380d68d804f
-    name: "py3.8-cuda-11.4.2-2"
+    name: "py3.8-v1-cuda-11.4.2-2"
     referencePolicy:
       type: Local

--- a/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/jupyter/minimal/ubi8-python-3.8"
+    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/jupyter/minimal"
     opendatahub.io/notebook-image-name: "Minimal Python"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
     opendatahub.io/notebook-image-order: "10"
@@ -13,11 +13,24 @@ spec:
   lookupPolicy:
     local: true
   tags:
+  # N Version of the image (v2-2023a-20230322-9f24e3e)
+  - annotations:
+      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.5"}, {"name": "Notebook","version": "6.5"}]'
+      openshift.io/imported-from: quay.io/modh/odh-minimal-notebook-container
+      opendatahub.io/workbench-image-recommended: 'true'
+      opendatahub.io/default-image: "true"
+    from:
+      kind: DockerImage
+      name: quay.io/modh/odh-minimal-notebook-container@sha256:43c88006d3bf71513b5e265a9bcf09b315aaa2142b6175c0e618829927dbaac2
+    name: "py3.9-v2"
+    referencePolicy:
+      type: Local
+  # N-1 Version of the image
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.2"}, {"name": "Notebook","version": "6.4"}]'
       openshift.io/imported-from: quay.io/modh/odh-minimal-notebook-container
-      opendatahub.io/default-image: "true"
     from:
       kind: DockerImage
       name: quay.io/modh/odh-minimal-notebook-container@sha256:a5a7738b09a204804e084a45f96360b568b0b9d85709c0ce6742d440ff917183

--- a/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/blob/main/jupyter/pytorch/ubi8-python-3.8"
+    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/blob/main/jupyter/pytorch"
     opendatahub.io/notebook-image-name: "PyTorch"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "40"
@@ -13,6 +13,19 @@ spec:
   lookupPolicy:
     local: true
   tags:
+  # N Version of the image (v2-2023a-20230322-9f24e3e)
+  - annotations:
+      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.13"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
+      openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
+      opendatahub.io/workbench-image-recommended: 'true'
+    from:
+      kind: DockerImage
+      name: quay.io/modh/odh-pytorch-notebook@sha256:9eb63a61da203178ff2579861a39efedd264447aa45a787d6b7bd9b08c13b1af
+    name: "py3.9-v2"
+    referencePolicy:
+      type: Local
+  # N-1 Version of the image
   - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.8"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'

--- a/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     opendatahub.io/notebook-image: "true"
   annotations:
-    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/blob/main/jupyter/tensorflow/ubi8-python-3.8"
+    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/blob/main/jupyter/tensorflow"
     opendatahub.io/notebook-image-name: "TensorFlow"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "50"
@@ -13,6 +13,19 @@ spec:
   lookupPolicy:
     local: true
   tags:
+  # N Version of the image (2023a-20230322-9f24e3e)
+  - annotations:
+      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.11"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.11"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
+      openshift.io/imported-from: quay.io/modh/cuda-notebooks
+      opendatahub.io/workbench-image-recommended: 'true'
+    from:
+      kind: DockerImage
+      name: quay.io/modh/cuda-notebooks@sha256:0070bf826f759be89068133edf73ba73855263c9788624b4f94dd3acb14d23b7
+    name: "py3.9-v2-cuda-11.8.0"
+    referencePolicy:
+      type: Local
+  # N-1 Version of the image
   - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.7"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'

--- a/jupyterhub/notebook-images/overlays/additional/trustyai-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/trustyai-notebook-imagestream.yaml
@@ -1,0 +1,26 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/jupyter/trustyai"
+    opendatahub.io/notebook-image-name: "TrustyAI"
+    opendatahub.io/notebook-image-desc: "Jupyter TrustyAI notebook integrates the TrustyAI Explainability Toolkit on Jupyter environment."
+    opendatahub.io/notebook-image-order: "60"
+  name: odh-trustyai-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  # N version of the image (2023a-20230324-9f24e3e)
+  - annotations:
+      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.2"}, {"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
+      openshift.io/imported-from: quay.io/modh/odh-trustyai-notebook
+    from:
+      kind: DockerImage
+      name: quay.io/modh/odh-trustyai-notebook@sha256:f8be3f6622d4bca653568e9c8b43363a842808d4669a3cd397f0d3a4f9a4c165
+    name: "py3.9-v1"
+    referencePolicy:
+      type: Local


### PR DESCRIPTION
This PR updates RHODS OOTB image streams: with N & N-1 versions and TrustyAi notebook.

1. Updated minimal, minimal-gpu, data science, tensorflow, and pytorch image streams  to support a second tag for the n & n-1 purposes.
2. Added the new TrustyAI image

Live Build:
**quay.io/rh_ee_atheodor/rhods-operator-live-catalog:1.24.0-rhodss-25517469**

![Screenshot from 2023-03-24 11-41-26](https://user-images.githubusercontent.com/42587738/227501237-e7654553-fbbc-4866-b90f-713a6f351beb.png)


- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-6041, https://issues.redhat.com/browse/RHODS-7469
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
