### PR TITLE
Update manifests to match v1.6.1 KF manifests

### DIFF
--- a/odh-notebook-controller/kf-notebook-controller/base/kustomization.yaml
+++ b/odh-notebook-controller/kf-notebook-controller/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
 - ../default
 images:
-- name: public.ecr.aws/j1r0q0g6/notebooks/notebook-controller
-  newName: public.ecr.aws/j1r0q0g6/notebooks/notebook-controller
-  newTag: v1.5.0
+- name: docker.io/kubeflownotebookswg/notebook-controller
+  newTag: v1.6.1
 

--- a/odh-notebook-controller/kf-notebook-controller/crd/bases/kubeflow.org_notebooks.yaml
+++ b/odh-notebook-controller/kf-notebook-controller/crd/bases/kubeflow.org_notebooks.yaml
@@ -3076,13 +3076,19 @@ spec:
                     lastProbeTime:
                       format: date-time
                       type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
                     message:
                       type: string
                     reason:
                       type: string
+                    status:
+                      type: string
                     type:
                       type: string
                   required:
+                  - status
                   - type
                   type: object
                 type: array
@@ -6199,13 +6205,19 @@ spec:
                     lastProbeTime:
                       format: date-time
                       type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
                     message:
                       type: string
                     reason:
                       type: string
+                    status:
+                      type: string
                     type:
                       type: string
                   required:
+                  - status
                   - type
                   type: object
                 type: array
@@ -9322,13 +9334,19 @@ spec:
                     lastProbeTime:
                       format: date-time
                       type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
                     message:
                       type: string
                     reason:
                       type: string
+                    status:
+                      type: string
                     type:
                       type: string
                   required:
+                  - status
                   - type
                   type: object
                 type: array

--- a/odh-notebook-controller/kf-notebook-controller/manager/manager.yaml
+++ b/odh-notebook-controller/kf-notebook-controller/manager/manager.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: manager
-        image: public.ecr.aws/j1r0q0g6/notebooks/notebook-controller
+        image: docker.io/kubeflownotebookswg/notebook-controller
         command:
           - /manager
         env:


### PR DESCRIPTION
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s): https://issues.redhat.com/browse/RHODS-7667
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
