### PR TITLE
Sync with component repo.

### DIFF
--- a/data-science-pipelines-operator/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/data-science-pipelines-operator/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -121,6 +121,10 @@ spec:
                     type: boolean
                   terminateStatus:
                     default: Cancelled
+                    enum:
+                    - Cancelled
+                    - StoppedRunFinally
+                    - CancelledRunFinally
                     type: string
                   trackArtifacts:
                     default: true

--- a/data-science-pipelines-operator/crd/external/monitoring.coreos.com_servicemonitors.yaml
+++ b/data-science-pipelines-operator/crd/external/monitoring.coreos.com_servicemonitors.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - endpoints
+                - selector
+              properties:
+                endpoints:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - path
+                      - port
+                    properties:
+                      path:
+                        type: string
+                      port:
+                        type: string
+                  minItems: 1
+                selector:
+                  type: object
+                  properties:
+                    matchLabels:
+                      type: object
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                  format: int64
+  scope: Namespaced
+  names:
+    plural: servicemonitors
+    singular: servicemonitor
+    kind: ServiceMonitor

--- a/data-science-pipelines-operator/manager/manager.yaml
+++ b/data-science-pipelines-operator/manager/manager.yaml
@@ -75,7 +75,7 @@ spec:
         resources:
           limits:
             cpu: 1
-            memory: 2Gi
+            memory: 4Gi
           requests:
             cpu: 1
             memory: 2Gi

--- a/data-science-pipelines-operator/rbac/aggregate_dspa_role.yaml
+++ b/data-science-pipelines-operator/rbac/aggregate_dspa_role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-dspa-admin-edit
+rules:
+  - apiGroups:
+      - datasciencepipelinesapplications.opendatahub.io
+    resources:
+      - datasciencepipelinesapplications
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete

--- a/data-science-pipelines-operator/rbac/kustomization.yaml
+++ b/data-science-pipelines-operator/rbac/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- aggregate_dspa_role.yaml

--- a/data-science-pipelines-operator/rbac/role.yaml
+++ b/data-science-pipelines-operator/rbac/role.yaml
@@ -155,6 +155,18 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies


### PR DESCRIPTION
* dspo now adds monitoring for dspa via service monitors
* additional validation
* allow admin/edit ocp roles to deploy DSPA: [(JIRA)](https://issues.redhat.com/secure/RapidBoard.jspa?rapidView=9441&projectKey=RHODS&view=detail&selectedIssue=RHODS-7615&quickFilter=102203)

## Testing Instructions: 


**live builder image**
`quay.io/hukhan/rhods-operator-live-catalog:1.25.0-dspo-18`
Create a DSPA CR as an OCP user that has either the `edit` or `admin` role.

**or test manually**
* Deploy RHODS-Operator

* Deploy the following kfdef: 

```yaml
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
   name: data-science-pipelines-operator
   namespace: redhat-ods-applications
spec:
   applications:
      - kustomizeConfig:
           repoRef:
              name: manifests
              path: data-science-pipelines-operator/
        name: data-science-pipelines-operator
   repos:
      - name: manifests
        uri: "https://github.com/HumairAK/odh-manifests/tarball/rhods-main-2"
```

Create a DSPA CR as an OCP user that has either the `edit` or `admin` role.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-7615
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
