### PR TITLE
[1.26] Update OVMS to point to openshift-ci built GPU img

### DIFF
--- a/model-mesh/base/params.env
+++ b/model-mesh/base/params.env
@@ -3,6 +3,6 @@ monitoring-namespace=
 odh-mm-rest-proxy=quay.io/opendatahub/rest-proxy:v0.11.0-alpha
 odh-modelmesh-runtime-adapter=quay.io/opendatahub/modelmesh-runtime-adapter:v0.11.0-alpha
 odh-modelmesh=quay.io/opendatahub/modelmesh:v0.11.0-alpha
-odh-openvino=quay.io/opendatahub/openvino_model_server:2022.3-gpu
+odh-openvino=quay.io/modh/openvino-model-server:2022.3-release
 odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:v0.11.0-alpha
 odh-model-controller=quay.io/opendatahub/odh-model-controller:v0.9.6-auth

--- a/model-mesh/runtimes/kustomization.yaml
+++ b/model-mesh/runtimes/kustomization.yaml
@@ -26,8 +26,8 @@ images:
     newTag: 0.5.2
 
   - name: ovms-1
-    newName: quay.io/opendatahub/openvino_model_server
-    newTag: 2022.3-gpu
+    newName: quay.io/modh/openvino-model-server
+    newTag: 2022.3-release
 
 transformers:
   - ../default/metadataLabelTransformer.yaml


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-6529
- [X] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

This points us to the new image, this is the openshift-ci built image that includes Nvidia GPU inferencing support

Really for 1.26, since we still need to remove it from CPaaS, but that branch doesn't exist yet