### PR TITLE
Add github workflow to update notebooks digests

### DIFF
--- a/.github/workflows/notebooks-digest-updater-downstream.yaml
+++ b/.github/workflows/notebooks-digest-updater-downstream.yaml
@@ -1,0 +1,112 @@
+# The aim of this GitHub workflow is to update the params.env file with the latest digest.
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        required: true
+        description: "Provide the name of the branch you want to update ex master, rhods-x.xx etc"
+      release-n:
+        required: true
+        description: "Provide release N version of the notebooks ex 2023a"
+  schedule:
+    - cron:  "0 0 * * 5" #Scheduled every Friday
+env:
+  DIGEST_UPDATER_BRANCH: digest-updater-${{ github.run_id }}
+  BRANCH_NAME: ${{ github.event.inputs.branch || 'master' }}
+  RELEASE_VERSION: ${{ github.event.inputs.release-n || '2023a' }}
+jobs:
+  initialize:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Install Skopeo CLI
+        shell: bash
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install skopeo
+
+      # Checkout the release branch
+      - name: Checkout release branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+
+      # Create a new branch
+      - name: Create a new branch
+        run: |
+         echo ${{ env.DIGEST_UPDATER_BRANCH }}
+         git checkout -b ${{ env.DIGEST_UPDATER_BRANCH }}
+         git push --set-upstream origin ${{ env.DIGEST_UPDATER_BRANCH }}
+
+  update-n-version:
+    needs: [ initialize ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Configure Git
+        run: |
+         git config --global user.email "github-actions[bot]@users.noreply.github.com"
+         git config --global user.name "GitHub Actions"
+
+      # Get the latest weekly build commit hash: https://github.com/opendatahub-io/notebooks/commits/2023a
+      - name: Checkout upstream notebooks repo
+        uses: actions/checkout@v3
+        with:
+         repository: red-hat-data-services/notebooks
+         ref: release-${{ env.RELEASE_VERSION }}
+      - name: Retrive latest weekly commit hash from the release branch
+        id: hash
+        shell: bash
+        run: |
+          echo "HASH=$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
+
+      # Checkout the release branch to apply the updates
+      - name: Checkout release branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.DIGEST_UPDATER_BRANCH }}
+
+      - name: Fetch digest, and update the param.env file
+        run: |
+              IMAGES=("odh-minimal-notebook-image-n" "odh-minimal-gpu-notebook-image-n" "odh-pytorch-gpu-notebook-image-n" "odh-generic-data-science-notebook-image-n" "odh-tensorflow-gpu-notebook-image-n" "odh-trustyai-notebook-image-n")
+              REGEXES=("v2-${{ env.RELEASE_VERSION }}-\d{8}+-${{ steps.hash.outputs.HASH }}" "cuda-[a-z]+-minimal-[a-z0-9]+-[a-z]+-3.9-${{ env.RELEASE_VERSION }}-\d{8}-${{ steps.hash.outputs.HASH }}" "v2-${{ env.RELEASE_VERSION }}-\d{8}+-${{ steps.hash.outputs.HASH }}" \
+                       "v2-${{ env.RELEASE_VERSION }}-\d{8}+-${{ steps.hash.outputs.HASH }}" "cuda-[a-z]+-tensorflow-[a-z0-9]+-[a-z]+-3.9-${{ env.RELEASE_VERSION }}-\d{8}-${{ steps.hash.outputs.HASH }}" "v1-${{ env.RELEASE_VERSION }}}-\d{8}+-${{ steps.hash.outputs.HASH }}")
+
+              for ((i=0;i<${#IMAGES[@]};++i)); do
+                image=${IMAGES[$i]}
+                echo $image
+                regex=${REGEXES[$i]}
+                img=$(cat jupyterhub/notebook-images/overlays/additional/params.env | grep -E "${image}=" | cut -d '=' -f2)
+                registry=$(echo $img | cut -d '@' -f1)
+                latest_tag=$(skopeo inspect docker://$img | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
+                digest=$(skopeo inspect docker://$registry:$latest_tag | jq .Digest | tr -d '"')
+                output=$registry@$digest
+                echo $output
+                sed -i "s|${image}=.*|${image}=$output|" jupyterhub/notebook-images/overlays/additional/params.env
+              done
+              git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && git add jupyterhub/notebook-images/overlays/additional/params.env && git commit -m "Update file via digest-updater GitHub action" && git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
+
+  open-pull-request:
+    needs: [ update-n-version ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: pull-request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: ${{ env.DIGEST_UPDATER_BRANCH }}
+          destination_branch: ${{ env.BRANCH_NAME}}
+          github_token: ${{ secrets.GH_ACCESS_TOKEN }}
+          pr_label: "automated pr"
+          pr_title: "[Digest Updater Action] Update notebook's imageStreams image tag to digest format"
+          pr_body: |
+            :rocket: This is a automated PR
+
+            _Created by `/.github/workflows/digest-updater.yaml`
+
+            :exclamation: **IMPORTANT NOTE**: Remember to delete the `${{ env.DIGEST_UPDATER_BRANCH }}` branch after merging the changes


### PR DESCRIPTION
## Description
Add GitHub action to update notebook's params.env file with the latest image digests. This is connected with the latest changes which introduce this PR: https://github.com/red-hat-data-services/odh-manifests/pull/332

This Action can be triggered **Manually** (as the testing steps indicate)  as well as **Scheduled** every Friday using the master as branch to be updated and 2023a for the N version of the notebooks. 
The user should provide on the workflow as input parameters 
- the branch that wants to update and 
- the released version of the image. 

When the workflow finishes its job it opens a Pull request to be reviewed by the user. This can be also scheduled and the updates to go directly into the main branch.

**IMPORTANT**: This workflow needs a github_token with the name `GH_ACCESS_TOKEN` to generate the PR 

**Note**: This workflow updates only the N version of the notebooks since the older version of the images N-1, belongs to the old implementation and cannot support the weekly updates. However, we plan to have an n-1 configuration available when the current N version becomes outdated. Therefore, the 2023a release will be based on the n-1 configuration, while the 2023b release will be based on the new N configuration. Eventually, we can apply a new job named: update-n-1-version to update the N-1 version as well.

## How Has Been Tested?

Created a demo repo for development and test purposes that simulates the core functionalities of the odh-manifest filesystem: https://github.com/atheo89/autorefresh-image-digest-workflow

1. Get Input from User 
![image](https://user-images.githubusercontent.com/42587738/230643299-a6d8d50e-fff2-4594-8dbe-e72ca6fc97b3.png)

2. Ensure that everything is green
![image](https://user-images.githubusercontent.com/42587738/230643574-e64bc877-8069-45d3-b07b-3deb1ad5ed5a.png)

3. Review the  automated PR 
![image](https://user-images.githubusercontent.com/42587738/230643690-a9927764-9890-475a-9f94-32a10f84006f.png)



- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-7422
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
