### PR TITLE
Lower resources for dspo 

### DIFF
--- a/data-science-pipelines-operator/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/data-science-pipelines-operator/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -72,6 +72,9 @@ spec:
                   enableOauth:
                     default: true
                     type: boolean
+                  enableSamplePipeline:
+                    default: true
+                    type: boolean
                   image:
                     type: string
                   injectDefaultScript:

--- a/data-science-pipelines-operator/manager/manager.yaml
+++ b/data-science-pipelines-operator/manager/manager.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       annotations:
@@ -78,8 +78,8 @@ spec:
             cpu: 1
             memory: 4Gi
           requests:
-            cpu: 1
-            memory: 2Gi
+            cpu: 10m
+            memory: 64Mi
         volumeMounts:
           - mountPath: /home/config
             name: config


### PR DESCRIPTION
# Description
PR lowers resource requirements for dspo as per: 
* https://issues.redhat.com/browse/RHODS-7943


We have perf tested with these resource requirements with 2k users w/o any crashes.

# Testing instructions 
Live build: `quay.io/hukhan/rhods-operator-live-catalog:1.26.0-7943-1`

Deploy DSPO, create DSPA, test whether you can run a pipeline. Confirm DSPO resources requirements/limits are as expected.

There's also a small change to accomodate [this change](https://github.com/red-hat-data-services/data-science-pipelines-operator/commit/cbf76c8c557b51b7ad97a7864ee8ea95c27e8048) from component repo. This doesn't need testing.




- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s):
    * https://issues.redhat.com/browse/RHODS-7943
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
