### PR TITLE
[1.26] Fix tag's names on notebooks imagestreams with better naming

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
@@ -22,7 +22,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/modh/odh-generic-data-science-notebook@sha256:46dbee9764ae96d95fb5719446226bf0b86ec1e8cc695ac12df575a352d79f8f
-    name: "py3.9-v2"
+    name: "2023.1"
     referencePolicy:
       type: Local
   # N-1 Version of the image
@@ -33,6 +33,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/modh/odh-generic-data-science-notebook@sha256:ebb5613e6b53dc4e8efcfe3878b4cd10ccb77c67d12c00d2b8c9d41aeffd7df5
-    name: "py3.8-v1"
+    name: "1.2"
     referencePolicy:
       type: Local

--- a/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
@@ -22,7 +22,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/modh/cuda-notebooks@sha256:a6080e64d9b70683d8f19334d85e5df7d574f260e2923568e1c5d955d2a8bdc5
-    name: "py3.9-v2-cuda-11.8.0"
+    name: "2023.1-cuda-11.8"
     referencePolicy:
       type: Local
   # N-1 Version of the image
@@ -33,6 +33,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/modh/cuda-notebooks@sha256:348fa993347f86d1e0913853fb726c584ae8b5181152f0430967d380d68d804f
-    name: "py3.8-v1-cuda-11.4.2-2"
+    name: "1.2-cuda-11.4"
     referencePolicy:
       type: Local
+

--- a/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
@@ -23,7 +23,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/modh/odh-minimal-notebook-container@sha256:43c88006d3bf71513b5e265a9bcf09b315aaa2142b6175c0e618829927dbaac2
-    name: "py3.9-v2"
+    name: "2023.1"
     referencePolicy:
       type: Local
   # N-1 Version of the image
@@ -34,6 +34,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/modh/odh-minimal-notebook-container@sha256:a5a7738b09a204804e084a45f96360b568b0b9d85709c0ce6742d440ff917183
-    name: "py3.8-v1"
+    name: "1.2"
     referencePolicy:
       type: Local

--- a/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
@@ -22,7 +22,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/modh/odh-pytorch-notebook@sha256:9eb63a61da203178ff2579861a39efedd264447aa45a787d6b7bd9b08c13b1af
-    name: "py3.9-v2"
+    name: "2023.1"
     referencePolicy:
       type: Local
   # N-1 Version of the image
@@ -33,6 +33,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/modh/cuda-notebooks@sha256:492c37fb4b71c07d929ac7963896e074871ded506230fe926cdac21eb1ab9db8
-    name: "py3.8-cuda-11.4.2-2"
+    name: "1.2"
     referencePolicy:
       type: Local

--- a/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
@@ -22,7 +22,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/modh/cuda-notebooks@sha256:0070bf826f759be89068133edf73ba73855263c9788624b4f94dd3acb14d23b7
-    name: "py3.9-v2-cuda-11.8.0"
+    name: "2023.1-cuda-11.8"
     referencePolicy:
       type: Local
   # N-1 Version of the image
@@ -33,6 +33,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/modh/cuda-notebooks@sha256:2163ba74f602ec4b3049a88dcfa4fe0a8d0fff231090001947da66ef8e75ab9a
-    name: "py3.8-cuda-11.4.2-2"
+    name: "1.2-cuda-11.4"
     referencePolicy:
       type: Local

--- a/jupyterhub/notebook-images/overlays/additional/trustyai-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/trustyai-notebook-imagestream.yaml
@@ -21,6 +21,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/modh/odh-trustyai-notebook@sha256:f8be3f6622d4bca653568e9c8b43363a842808d4669a3cd397f0d3a4f9a4c165
-    name: "py3.9-v1"
+    name: "2023.1"
     referencePolicy:
       type: Local


### PR DESCRIPTION
follow up of https://github.com/red-hat-data-services/odh-manifests/pull/336 for 1.16 release branch

