### PR TITLE
Remove upstream image reference for dspo defaults.

### DIFF
--- a/data-science-pipelines-operator/README.md
+++ b/data-science-pipelines-operator/README.md
@@ -29,6 +29,11 @@ DSPO_NS=redhat-ods-applications
 oc new-project ${DSPO_NS}
 ```
 
+Set the latest RHODS version released in the following env var: 
+```bash
+RHODS_VERSION=rhods-1.25
+```
+
 Then deploy the following `KfDef` into the namespace created above:
 
 ```bash
@@ -47,9 +52,12 @@ spec:
         name: data-science-pipelines-operator
    repos:
       - name: manifests
-        uri: "https://github.com/red-hat-data-services/odh-manifests/tarball/master"
+        uri: "https://github.com/red-hat-data-services/odh-manifests/tarball/${RHODS_VERSION}"
 EOF
 ```
+
+> Note: To you use a non-latest release, update RHODS_VERSION, but also update the image tags in `/base/params.env`
+> to point to the version matched with RHODS_VERSION
 
 Confirm the pods are successfully deployed and reach running state:
 

--- a/data-science-pipelines-operator/base/params.env
+++ b/data-science-pipelines-operator/base/params.env
@@ -6,4 +6,4 @@ IMAGES_VIEWERCRD=registry.redhat.io/rhods/odh-ml-pipelines-viewercontroller-rhel
 IMAGES_CACHE=registry.redhat.io/rhods/odh-ml-pipelines-cache-rhel8:latest
 IMAGES_MOVERESULTSIMAGE=registry.redhat.io/ubi8/ubi-micro:8.7
 IMAGES_MARIADB=registry.redhat.io/rhel8/mariadb-103:1
-IMAGES_DSPO=quay.io/opendatahub/data-science-pipelines-operator:latest
+IMAGES_DSPO=registry.redhat.io/rhods/odh-data-science-pipelines-operator-controller-rhel8:latest


### PR DESCRIPTION
This is a purely cosmetic change, as the real location where images are specified is in the deployer, see [here](https://github.com/red-hat-data-services/odh-deployer/blob/main/kfdefs/rhods-data-science-pipelines-operator.yaml#L22). 

This is mostly to remove references to upstream images, so as not to confuse others.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-7708
- [ ] The Jira story is acked 
  - cosmetic change, no actual code change to rhods being made so no ack needed
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
