### PR TITLE
Add DSP Operator specific labels

### DIFF
--- a/data-science-pipelines-operator/manager/manager-service.yaml
+++ b/data-science-pipelines-operator/manager/manager-service.yaml
@@ -3,11 +3,10 @@ kind: Service
 metadata:
   name: service
   labels:
-    control-plane: controller-manager
-    app.kubernetes.io/created-by: data-science-pipelines-operator
+    app.kubernetes.io/name: data-science-pipelines-operator
 spec:
   ports:
     - name: metrics
       port: 8080
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: data-science-pipelines-operator

--- a/data-science-pipelines-operator/manager/manager.yaml
+++ b/data-science-pipelines-operator/manager/manager.yaml
@@ -4,24 +4,18 @@ metadata:
   name: controller-manager
   namespace: datasciencepipelinesapplications-controller
   labels:
-    control-plane: controller-manager
-    app.kubernetes.io/name: deployment
-    app.kubernetes.io/instance: controller-manager
-    app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: data-science-pipelines-operator
-    app.kubernetes.io/part-of: data-science-pipelines-operator
+    app.kubernetes.io/name: data-science-pipelines-operator
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: data-science-pipelines-operator
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
-        app.kubernetes.io/created-by: data-science-pipelines-operator
+        app.kubernetes.io/name: data-science-pipelines-operator
     spec:
       securityContext:
         runAsNonRoot: true

--- a/data-science-pipelines-operator/prometheus/monitor.yaml
+++ b/data-science-pipelines-operator/prometheus/monitor.yaml
@@ -9,4 +9,4 @@ spec:
       port: metrics
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: data-science-pipelines-operator

--- a/data-science-pipelines-operator/rbac/leader_election_role.yaml
+++ b/data-science-pipelines-operator/rbac/leader_election_role.yaml
@@ -3,11 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: role
-    app.kubernetes.io/instance: leader-election-role
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: data-science-pipelines-operator
-    app.kubernetes.io/part-of: data-science-pipelines-operator
+    app.kubernetes.io/name: data-science-pipelines-operator
   name: leader-election-role
 rules:
 - apiGroups:

--- a/data-science-pipelines-operator/rbac/leader_election_role_binding.yaml
+++ b/data-science-pipelines-operator/rbac/leader_election_role_binding.yaml
@@ -2,11 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/instance: leader-election-rolebinding
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: data-science-pipelines-operator
-    app.kubernetes.io/part-of: data-science-pipelines-operator
+    app.kubernetes.io/name: data-science-pipelines-operator
   name: leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/data-science-pipelines-operator/rbac/role_binding.yaml
+++ b/data-science-pipelines-operator/rbac/role_binding.yaml
@@ -2,11 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/instance: manager-rolebinding
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: data-science-pipelines-operator
-    app.kubernetes.io/part-of: data-science-pipelines-operator
+    app.kubernetes.io/name: data-science-pipelines-operator
   name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/data-science-pipelines-operator/rbac/service_account.yaml
+++ b/data-science-pipelines-operator/rbac/service_account.yaml
@@ -2,10 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: data-science-pipelines-operator
-    app.kubernetes.io/part-of: data-science-pipelines-operator
+    app.kubernetes.io/name: data-science-pipelines-operator
   name: controller-manager
   namespace: datasciencepipelinesapplications-controller


### PR DESCRIPTION
Update DSP Operator labels to be more specific to DSP/DSPO. Closes
Relevant component repo PR: https://github.com/opendatahub-io/data-science-pipelines-operator/pull/110
Cherry picked from https://github.com/red-hat-data-services/odh-manifests/pull/360

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s): 
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
