### PR TITLE
sync up new updated image of workbench per 0cf2501 commit

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
@@ -13,7 +13,7 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # N Version of the image (v2-2023a-20230510-e348fda)
+  # N Version of the image (v2-2023a-20230516-0cf2501)
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
@@ -21,7 +21,7 @@ spec:
       opendatahub.io/workbench-image-recommended: 'true'
     from:
       kind: DockerImage
-      name: quay.io/modh/odh-generic-data-science-notebook@sha256:2d4669d8d06f7945a3bfa511c5a18eb75fd1b0b6f6d7d43ecd3c24dd1fe3b03b
+      name: quay.io/modh/odh-generic-data-science-notebook@sha256:b89ff6ecb174e00749ea0fb47abd4909bb992d2b48e95d0e28089a0d7fd83100
     name: "2023.1"
     referencePolicy:
       type: Local

--- a/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
@@ -13,7 +13,7 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # N Version of the image (2023a-20230510-e348fda)
+  # N Version of the image (2023a-20230516-0cf2501)
   - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.5"},{"name":"Notebook","version":"6.5"}]'
@@ -21,7 +21,7 @@ spec:
         opendatahub.io/workbench-image-recommended: 'true'
     from:
       kind: DockerImage
-      name: quay.io/modh/cuda-notebooks@sha256:50e1ab299f12310b8187034648620ca8b03e0f82acc1abeb9e96df0af9ebc77c
+      name: quay.io/modh/cuda-notebooks@sha256:b899e5160df29ac80c62512bdbc9499e86dcb1843ade11d5c861ba6f2c41cb37
     name: "2023.1-cuda-11.8"
     referencePolicy:
       type: Local

--- a/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
@@ -13,7 +13,7 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # N Version of the image (v2-2023a-20230510-e348fda)
+  # N Version of the image (v2-2023a-20230516-0cf2501)
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.5"}, {"name": "Notebook","version": "6.5"}]'
@@ -22,7 +22,7 @@ spec:
       opendatahub.io/default-image: "true"
     from:
       kind: DockerImage
-      name: quay.io/modh/odh-minimal-notebook-container@sha256:5c89d8125e91fd4ea5da58f910d6f73a239bc46363371be109bf512b4feb2fa9
+      name: quay.io/modh/odh-minimal-notebook-container@sha256:d1b4fd1c24323806749ffdc7f89a8a44ea2077e50f06e13fcdb01fbd94e6cb64
     name: "2023.1"
     referencePolicy:
       type: Local

--- a/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
@@ -13,7 +13,7 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # N Version of the image (v2-2023a-20230510-e348fda)
+  # N Version of the image (v2-2023a-20230516-0cf2501)
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.13"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
@@ -21,7 +21,7 @@ spec:
       opendatahub.io/workbench-image-recommended: 'true'
     from:
       kind: DockerImage
-      name: quay.io/modh/odh-pytorch-notebook@sha256:0958147938a0d7bea494f81fecdef4622ea9501ef96010f8c2e82b4c2254ac00
+      name: quay.io/modh/odh-pytorch-notebook@sha256:f530288fe2536aa13b78fb73d07d3831ff7a24141a56628201be79192566e69f
     name: "2023.1-cuda-11.7"
     referencePolicy:
       type: Local

--- a/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
@@ -13,7 +13,7 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # N Version of the image (2023a-20230510-e348fda)
+  # N Version of the image (2023a-20230516-0cf2501)
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.11"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.11"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
@@ -21,7 +21,7 @@ spec:
       opendatahub.io/workbench-image-recommended: 'true'
     from:
       kind: DockerImage
-      name: quay.io/modh/cuda-notebooks@sha256:9591bbb89cea55d6717a76c072d3cea06743eaa7fed02ec20346cf581c2b2fd1
+      name: quay.io/modh/cuda-notebooks@sha256:7cd89e5e8612cfa246e8373b1edeeb5c0901bcd6db4421c94eaa40a1589dcd42
     name: "2023.1-cuda-11.8"
     referencePolicy:
       type: Local

--- a/jupyterhub/notebook-images/overlays/additional/trustyai-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/trustyai-notebook-imagestream.yaml
@@ -13,14 +13,14 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # N version of the image (v1-2023a-20230510-e348fda)
+  # N version of the image (v1-2023a-20230516-0cf2501)
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.2"}, {"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
       openshift.io/imported-from: quay.io/modh/odh-trustyai-notebook
     from:
       kind: DockerImage
-      name: quay.io/modh/odh-trustyai-notebook@sha256:b643f752fd929b1c9cdf92107a6ade011ab496623233d1c0e8282d3b70716376
+      name: quay.io/modh/odh-trustyai-notebook@sha256:3ec0568dfee3ee98b0cca694b025db369f1ea79e5db033dff01af53826c44a97
     name: "2023.1"
     referencePolicy:
       type: Local


### PR DESCRIPTION
sync up new updated image of workbench per 0cf2501 commit

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-8373
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
