### PR TITLE
Move CUDA indication from the version to annotations

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
@@ -15,24 +15,24 @@ spec:
   tags:
   # N Version of the image (2023a-20230510-e348fda)
   - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.5"},{"name":"Notebook","version":"6.5"}]'
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/workbench-image-recommended: 'true'
     from:
       kind: DockerImage
       name: quay.io/modh/cuda-notebooks@sha256:50e1ab299f12310b8187034648620ca8b03e0f82acc1abeb9e96df0af9ebc77c
-    name: "2023.1-cuda-11.8"
+    name: "2023.1"
     referencePolicy:
       type: Local
   # N-1 Version of the image
   - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"}]'
+        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.2"},{"name":"Notebook","version":"6.4"}]'
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
     from:
       kind: DockerImage
       name: quay.io/modh/cuda-notebooks@sha256:348fa993347f86d1e0913853fb726c584ae8b5181152f0430967d380d68d804f
-    name: "1.2-cuda-11.4"
+    name: "1.2"
     referencePolicy:
       type: Local

--- a/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
@@ -15,24 +15,24 @@ spec:
   tags:
   # N Version of the image (v2-2023a-20230510-e348fda)
   - annotations:
-      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
+      opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.7"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.13"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
       openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
       opendatahub.io/workbench-image-recommended: 'true'
     from:
       kind: DockerImage
       name: quay.io/modh/odh-pytorch-notebook@sha256:0958147938a0d7bea494f81fecdef4622ea9501ef96010f8c2e82b4c2254ac00
-    name: "2023.1-cuda-11.7"
+    name: "2023.1"
     referencePolicy:
       type: Local
   # N-1 Version of the image
   - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"}]'
+        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.8"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
     from:
       kind: DockerImage
       name: quay.io/modh/cuda-notebooks@sha256:492c37fb4b71c07d929ac7963896e074871ded506230fe926cdac21eb1ab9db8
-    name: "1.2-cuda-11.4"
+    name: "1.2"
     referencePolicy:
       type: Local

--- a/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
@@ -15,24 +15,24 @@ spec:
   tags:
   # N Version of the image (2023a-20230510-e348fda)
   - annotations:
-      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.11"}]'
+      opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.11"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.11"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
       openshift.io/imported-from: quay.io/modh/cuda-notebooks
       opendatahub.io/workbench-image-recommended: 'true'
     from:
       kind: DockerImage
       name: quay.io/modh/cuda-notebooks@sha256:9591bbb89cea55d6717a76c072d3cea06743eaa7fed02ec20346cf581c2b2fd1
-    name: "2023.1-cuda-11.8"
+    name: "2023.1"
     referencePolicy:
       type: Local
   # N-1 Version of the image
   - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"}]'
+        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.7"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
     from:
       kind: DockerImage
       name: quay.io/modh/cuda-notebooks@sha256:2163ba74f602ec4b3049a88dcfa4fe0a8d0fff231090001947da66ef8e75ab9a
-    name: "1.2-cuda-11.4"
+    name: "1.2"
     referencePolicy:
       type: Local


### PR DESCRIPTION
This PR includes the CUDA tag version in the annotation list of the image itself rather than the version name.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-8215
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
