### PR TITLE
sync workbench images with commit c4c062e

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
@@ -13,7 +13,7 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # N Version of the image
+  # N Version of the image (v2-2023a-20230526-c4c062e)
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'

--- a/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
@@ -13,7 +13,7 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # N Version of the image
+  # N Version of the image (2023a-20230526-c4c062e)
   - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.5"},{"name":"Notebook","version":"6.5"}]'

--- a/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
@@ -13,7 +13,7 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # N Version of the image
+  # N Version of the image (v2-2023a-20230526-c4c062e)
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.5"}, {"name": "Notebook","version": "6.5"}]'

--- a/jupyterhub/notebook-images/overlays/additional/params.env
+++ b/jupyterhub/notebook-images/overlays/additional/params.env
@@ -1,11 +1,11 @@
-odh-minimal-notebook-image-n=quay.io/modh/odh-minimal-notebook-container@sha256:5c89d8125e91fd4ea5da58f910d6f73a239bc46363371be109bf512b4feb2fa9
+odh-minimal-notebook-image-n=quay.io/modh/odh-minimal-notebook-container@sha256:7f38fdefd20e5a11ba5077b3b653f0ef9b5e7b8832cef36f07fbc8e71508257e
 odh-minimal-notebook-image-n-1=quay.io/modh/odh-minimal-notebook-container@sha256:a5a7738b09a204804e084a45f96360b568b0b9d85709c0ce6742d440ff917183
-odh-minimal-gpu-notebook-image-n=quay.io/modh/cuda-notebooks@sha256:50e1ab299f12310b8187034648620ca8b03e0f82acc1abeb9e96df0af9ebc77c
+odh-minimal-gpu-notebook-image-n=quay.io/modh/cuda-notebooks@sha256:c65ad697a23f376914ea28e6a456760f3f384f945938390c92d3e08a74903e02
 odh-minimal-gpu-notebook-image-n-1=quay.io/modh/cuda-notebooks@sha256:348fa993347f86d1e0913853fb726c584ae8b5181152f0430967d380d68d804f
-odh-pytorch-gpu-notebook-image-n=quay.io/modh/odh-pytorch-notebook@sha256:0958147938a0d7bea494f81fecdef4622ea9501ef96010f8c2e82b4c2254ac00
+odh-pytorch-gpu-notebook-image-n=quay.io/modh/odh-pytorch-notebook@sha256:2bab7ffc31ff9c98281799361d3d1d5fc12bde15c0654c5c5a7b2caca00c5874
 odh-pytorch-gpu-notebook-image-n-1=quay.io/modh/cuda-notebooks@sha256:492c37fb4b71c07d929ac7963896e074871ded506230fe926cdac21eb1ab9db8
-odh-generic-data-science-notebook-image-n=quay.io/modh/odh-generic-data-science-notebook@sha256:2d4669d8d06f7945a3bfa511c5a18eb75fd1b0b6f6d7d43ecd3c24dd1fe3b03b
+odh-generic-data-science-notebook-image-n=quay.io/modh/odh-generic-data-science-notebook@sha256:8348e87eb75fd6813cc6fdfad054e31ea89195437be6543883a079f8af48bcbd
 odh-generic-data-science-notebook-image-n-1=quay.io/modh/odh-generic-data-science-notebook@sha256:ebb5613e6b53dc4e8efcfe3878b4cd10ccb77c67d12c00d2b8c9d41aeffd7df5
-odh-tensorflow-gpu-notebook-image-n=quay.io/modh/cuda-notebooks@sha256:9591bbb89cea55d6717a76c072d3cea06743eaa7fed02ec20346cf581c2b2fd1
+odh-tensorflow-gpu-notebook-image-n=quay.io/modh/cuda-notebooks@sha256:90d54e9eabcac15c8075c0b4d01277043638956ffab074e45786db361f910302
 odh-tensorflow-gpu-notebook-image-n-1=quay.io/modh/cuda-notebooks@sha256:2163ba74f602ec4b3049a88dcfa4fe0a8d0fff231090001947da66ef8e75ab9a
-odh-trustyai-notebook-image-n=quay.io/modh/odh-trustyai-notebook@sha256:b643f752fd929b1c9cdf92107a6ade011ab496623233d1c0e8282d3b70716376
+odh-trustyai-notebook-image-n=quay.io/modh/odh-trustyai-notebook@sha256:c1b584155ee2d2d7d102a85a7c9266e11093267da41137df940244e5293a80d1

--- a/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
@@ -13,7 +13,7 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # N Version of the image
+  # N Version of the image (v2-2023a-20230526-c4c062e)
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.13"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'

--- a/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
@@ -13,7 +13,7 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # N Version of the image
+  # N Version of the image (2023a-20230526-c4c062e)
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.11"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.11"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'

--- a/jupyterhub/notebook-images/overlays/additional/trustyai-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/trustyai-notebook-imagestream.yaml
@@ -13,7 +13,7 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # N version of the image
+  # N version of the image (v1-2023a-20230526-c4c062e)
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.2"}, {"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-8372 https://issues.redhat.com/browse/RHODS-7404
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)




List of the images:
- https://quay.io/repository/modh/odh-trustyai-notebook/manifest/sha256:c1b584155ee2d2d7d102a85a7c9266e11093267da41137df940244e5293a80d1
- https://quay.io/repository/modh/odh-pytorch-notebook/manifest/sha256:2bab7ffc31ff9c98281799361d3d1d5fc12bde15c0654c5c5a7b2caca00c5874
- https://quay.io/repository/modh/odh-minimal-notebook-container/manifest/sha256:7f38fdefd20e5a11ba5077b3b653f0ef9b5e7b8832cef36f07fbc8e71508257e
- https://quay.io/repository/modh/odh-generic-data-science-notebook/manifest/sha256:8348e87eb75fd6813cc6fdfad054e31ea89195437be6543883a079f8af48bcbd
- https://quay.io/repository/modh/cuda-notebooks/manifest/sha256:c65ad697a23f376914ea28e6a456760f3f384f945938390c92d3e08a74903e02
- https://quay.io/repository/modh/cuda-notebooks/manifest/sha256:90d54e9eabcac15c8075c0b4d01277043638956ffab074e45786db361f910302