### PR TITLE
[Cherry pick] Revert "Add DSP Operator specific labels"

### DIFF
--- a/data-science-pipelines-operator/manager/manager-service.yaml
+++ b/data-science-pipelines-operator/manager/manager-service.yaml
@@ -3,10 +3,11 @@ kind: Service
 metadata:
   name: service
   labels:
-    app.kubernetes.io/name: data-science-pipelines-operator
+    control-plane: controller-manager
+    app.kubernetes.io/created-by: data-science-pipelines-operator
 spec:
   ports:
     - name: metrics
       port: 8080
   selector:
-    app.kubernetes.io/name: data-science-pipelines-operator
+    control-plane: controller-manager

--- a/data-science-pipelines-operator/manager/manager.yaml
+++ b/data-science-pipelines-operator/manager/manager.yaml
@@ -4,18 +4,24 @@ metadata:
   name: controller-manager
   namespace: datasciencepipelinesapplications-controller
   labels:
-    app.kubernetes.io/name: data-science-pipelines-operator
+    control-plane: controller-manager
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: data-science-pipelines-operator
+    app.kubernetes.io/part-of: data-science-pipelines-operator
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: data-science-pipelines-operator
+      control-plane: controller-manager
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        app.kubernetes.io/name: data-science-pipelines-operator
+        control-plane: controller-manager
+        app.kubernetes.io/created-by: data-science-pipelines-operator
     spec:
       securityContext:
         runAsNonRoot: true

--- a/data-science-pipelines-operator/prometheus/monitor.yaml
+++ b/data-science-pipelines-operator/prometheus/monitor.yaml
@@ -9,4 +9,4 @@ spec:
       port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: data-science-pipelines-operator
+      control-plane: controller-manager

--- a/data-science-pipelines-operator/rbac/leader_election_role.yaml
+++ b/data-science-pipelines-operator/rbac/leader_election_role.yaml
@@ -3,7 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: data-science-pipelines-operator
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: data-science-pipelines-operator
+    app.kubernetes.io/part-of: data-science-pipelines-operator
   name: leader-election-role
 rules:
 - apiGroups:

--- a/data-science-pipelines-operator/rbac/leader_election_role_binding.yaml
+++ b/data-science-pipelines-operator/rbac/leader_election_role_binding.yaml
@@ -2,7 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: data-science-pipelines-operator
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: data-science-pipelines-operator
+    app.kubernetes.io/part-of: data-science-pipelines-operator
   name: leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/data-science-pipelines-operator/rbac/role_binding.yaml
+++ b/data-science-pipelines-operator/rbac/role_binding.yaml
@@ -2,7 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: data-science-pipelines-operator
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: data-science-pipelines-operator
+    app.kubernetes.io/part-of: data-science-pipelines-operator
   name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/data-science-pipelines-operator/rbac/service_account.yaml
+++ b/data-science-pipelines-operator/rbac/service_account.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: data-science-pipelines-operator
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: data-science-pipelines-operator
+    app.kubernetes.io/part-of: data-science-pipelines-operator
   name: controller-manager
   namespace: datasciencepipelinesapplications-controller


### PR DESCRIPTION
Cherry pick: https://github.com/red-hat-data-services/odh-manifests/pull/379

This reverts commit 3dd1441d1d36aad2a3d0b2ecb9f110deb0976b1a.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-8935
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
