### PR TITLE
Add pod anti-affinity to odh-model-controller manifests (#849)

### DIFF
--- a/model-mesh/odh-model-controller/manager/manager.yaml
+++ b/model-mesh/odh-model-controller/manager/manager.yaml
@@ -18,6 +18,18 @@ spec:
         control-plane: odh-model-controller
         app: odh-model-controller
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: control-plane
+                      operator: In
+                      values:
+                        - odh-model-controller
+                topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
       containers:


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-9343
- [x] The Jira story is acked
- [ ] ~~An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).~~
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

## How Has This Been Tested?
By deploying using the following KfDef:

```yaml
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  name: odh-core
spec:
  applications:
  - kustomizeConfig:
      repoRef:
        name: manifests
        path: odh-common
    name: odh-common
  - kustomizeConfig:
      parameters:
      - name: monitoring-namespace
        value: opendatahub
      repoRef:
        name: manifests
        path: model-mesh
    name: model-mesh
  - kustomizeConfig:
      parameters:
      - name: deployment-namespace
        value: opendatahub
      repoRef:
        name: manifests
        path: modelmesh-monitoring
    name: modelmesh-monitoring
  repos:
  - name: manifests
    uri: https://github.com/israel-hdez/odh-manifests/tarball/9343-podd-anti-affinities
  version: add-model-controller-anti-affinity
```

Then, verify that modelmesh-controller pods start correctly and they have anti-affinities properly set.
