### PR TITLE
[Cherry Pick] Add pod anti-affinity to odh-model-controller manifests (#849)

### DIFF
--- a/model-mesh/odh-model-controller/manager/manager.yaml
+++ b/model-mesh/odh-model-controller/manager/manager.yaml
@@ -18,6 +18,18 @@ spec:
         control-plane: odh-model-controller
         app: odh-model-controller
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: control-plane
+                      operator: In
+                      values:
+                        - odh-model-controller
+                topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
       containers:


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): : https://issues.redhat.com/browse/RHODS-9343
- [X] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
