### PR TITLE
[UPSTREAM] Fix rhods-9627

### DIFF
--- a/model-mesh/base/kustomization.yaml
+++ b/model-mesh/base/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - ../odh-modelmesh-controller/overlays/odh
   - ../odh-model-controller/overlays/odh
 
-commonLabels:
-  app.kubernetes.io/part-of: model-mesh
 namespace: opendatahub
 configMapGenerator:
   - envs:

--- a/model-mesh/odh-model-controller/overlays/odh/kustomization.yaml
+++ b/model-mesh/odh-model-controller/overlays/odh/kustomization.yaml
@@ -5,8 +5,6 @@ resources:
 
 patchesStrategicMerge:
   - odh_model_controller_manager_patch.yaml
-commonLabels:
-  app.kubernetes.io/managed-by: odh-model-controller
 
 configurations:
   - params.yaml

--- a/model-mesh/odh-modelmesh-controller/overlays/odh/kustomization.yaml
+++ b/model-mesh/odh-modelmesh-controller/overlays/odh/kustomization.yaml
@@ -9,7 +9,8 @@ resources:
   - ./manager
 
 commonLabels:
-  app.kubernetes.io/managed-by: modelmesh-controller
+  app: model-mesh
+  app.kubernetes.io/part-of: model-mesh
 
 configurations:
   - params.yaml


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s):https://issues.redhat.com/browse/RHODS-9627
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

This is from upstream: https://github.com/opendatahub-io/odh-manifests/pull/866
**Live Builder image: quay.io/jooholee/rhods-operator-live-catalog:1.29.0-rhods-9627**

