### PR TITLE
Set referencePolicy to source for pulling image directly (#846)

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
@@ -24,7 +24,7 @@ spec:
       name: $(odh-generic-data-science-notebook-image-n)
     name: "2023.1"
     referencePolicy:
-      type: Local
+      type: Source
   # N-1 Version of the image
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"}]'
@@ -35,4 +35,4 @@ spec:
       name: $(odh-generic-data-science-notebook-image-n-1)
     name: "1.2"
     referencePolicy:
-      type: Local
+      type: Source

--- a/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
@@ -24,7 +24,7 @@ spec:
       name: $(odh-minimal-gpu-notebook-image-n)
     name: "2023.1"
     referencePolicy:
-      type: Local
+      type: Source
   # N-1 Version of the image
   - annotations:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"}]'
@@ -35,4 +35,4 @@ spec:
       name: $(odh-minimal-gpu-notebook-image-n-1)
     name: "1.2"
     referencePolicy:
-      type: Local
+      type: Source

--- a/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
@@ -25,7 +25,7 @@ spec:
       name: $(odh-minimal-notebook-image-n)
     name: "2023.1"
     referencePolicy:
-      type: Local
+      type: Source
   # N-1 Version of the image
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"}]'
@@ -36,4 +36,4 @@ spec:
       name: $(odh-minimal-notebook-image-n-1)
     name: "1.2"
     referencePolicy:
-      type: Local
+      type: Source

--- a/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
@@ -24,7 +24,7 @@ spec:
       name: $(odh-pytorch-gpu-notebook-image-n)
     name: "2023.1"
     referencePolicy:
-      type: Local
+      type: Source
   # N-1 Version of the image
   - annotations:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"}]'
@@ -35,4 +35,4 @@ spec:
       name: $(odh-pytorch-gpu-notebook-image-n-1)
     name: "1.2"
     referencePolicy:
-      type: Local
+      type: Source

--- a/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
@@ -24,7 +24,7 @@ spec:
       name: $(odh-tensorflow-gpu-notebook-image-n)
     name: "2023.1"
     referencePolicy:
-      type: Local
+      type: Source
   # N-1 Version of the image
   - annotations:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"}]'
@@ -35,4 +35,4 @@ spec:
       name: $(odh-tensorflow-gpu-notebook-image-n-1)
     name: "1.2"
     referencePolicy:
-      type: Local
+      type: Source

--- a/jupyterhub/notebook-images/overlays/additional/trustyai-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/trustyai-notebook-imagestream.yaml
@@ -23,4 +23,4 @@ spec:
       name: $(odh-trustyai-notebook-image-n)
     name: "2023.1"
     referencePolicy:
-      type: Local
+      type: Source


### PR DESCRIPTION
Set referencePolicy to source for pulling image directly (#846)

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)


This was already existing in rhods-1.29
somehow it was missed in rhods-1.30
