### PR TITLE
[UPSTREAM] Fix software annotation to point the correct version on CUDA version (1.30 branch)

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
@@ -15,7 +15,7 @@ spec:
   tags:
   # N Version of the image (v2-2023a-20230526-c4c062e)
   - annotations:
-      opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.7"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
+      opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.13"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
       openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
       opendatahub.io/workbench-image-recommended: 'true'


### PR DESCRIPTION
This PR is meant to point to the correct version of the GPU. 
Had to show 11.8 instead 11.7
Related-to: https://github.com/opendatahub-io/notebooks/issues/150

UPSTREAM PR -> https://github.com/opendatahub-io/odh-manifests/pull/889

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-9421
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
