### PR TITLE
Add dsp 1.0.0 manifests.

### DIFF
--- a/data-science-pipelines-operator/base/kustomization.yaml
+++ b/data-science-pipelines-operator/base/kustomization.yaml
@@ -71,6 +71,27 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.IMAGES_MARIADB
+  - name: IMAGES_MLMDENVOY
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_MLMDENVOY
+  - name: IMAGES_MLMDGRPC
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_MLMDGRPC
+  - name: IMAGES_MLMDWRITER
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_MLMDWRITER
   - name: IMAGES_DSPO
     objref:
       kind: ConfigMap

--- a/data-science-pipelines-operator/base/params.env
+++ b/data-science-pipelines-operator/base/params.env
@@ -7,3 +7,6 @@ IMAGES_MOVERESULTSIMAGE=registry.redhat.io/ubi8/ubi-micro:8.7
 IMAGES_MARIADB=registry.redhat.io/rhel8/mariadb-103:1
 IMAGES_DSPO=registry.redhat.io/rhods/odh-data-science-pipelines-operator-controller-rhel8:latest
 IMAGES_OAUTHPROXY=registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+IMAGES_MLMDENVOY=upstream-only
+IMAGES_MLMDGRPC=upstream-only
+IMAGES_MLMDWRITER=upstream-only

--- a/data-science-pipelines-operator/configmaps/files/config.yaml
+++ b/data-science-pipelines-operator/configmaps/files/config.yaml
@@ -7,3 +7,6 @@ Images:
   Cache: $(IMAGES_CACHE)
   MoveResultsImage: $(IMAGES_MOVERESULTSIMAGE)
   MariaDB: $(IMAGES_MARIADB)
+  MlmdEnvoy: $(IMAGES_MLMDENVOY)
+  MlmdGRPC: $(IMAGES_MLMDGRPC)
+  MlmdWriter: $(IMAGES_MLMDWRITER)

--- a/data-science-pipelines-operator/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/data-science-pipelines-operator/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -235,6 +235,151 @@ spec:
                         type: string
                     type: object
                 type: object
+              mlmd:
+                default:
+                  deploy: false
+                properties:
+                  deploy:
+                    default: false
+                    type: boolean
+                  envoy:
+                    properties:
+                      image:
+                        type: string
+                      resources:
+                        description: ResourceRequirements structures compute resource
+                          requirements. Replaces ResourceRequirements from corev1
+                          which also includes optional storage field. We handle storage
+                          field separately, and should not include it as a subfield
+                          for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    required:
+                    - image
+                    type: object
+                  grpc:
+                    properties:
+                      image:
+                        type: string
+                      port:
+                        type: string
+                      resources:
+                        description: ResourceRequirements structures compute resource
+                          requirements. Replaces ResourceRequirements from corev1
+                          which also includes optional storage field. We handle storage
+                          field separately, and should not include it as a subfield
+                          for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    required:
+                    - image
+                    type: object
+                  writer:
+                    properties:
+                      image:
+                        type: string
+                      resources:
+                        description: ResourceRequirements structures compute resource
+                          requirements. Replaces ResourceRequirements from corev1
+                          which also includes optional storage field. We handle storage
+                          field separately, and should not include it as a subfield
+                          for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    required:
+                    - image
+                    type: object
+                type: object
               mlpipelineUI:
                 properties:
                   configMap:

--- a/data-science-pipelines-operator/manager/manager-service.yaml
+++ b/data-science-pipelines-operator/manager/manager-service.yaml
@@ -3,11 +3,10 @@ kind: Service
 metadata:
   name: service
   labels:
-    control-plane: controller-manager
-    app.kubernetes.io/created-by: data-science-pipelines-operator
+    app.kubernetes.io/name: data-science-pipelines-operator
 spec:
   ports:
     - name: metrics
       port: 8080
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: data-science-pipelines-operator

--- a/data-science-pipelines-operator/manager/manager.yaml
+++ b/data-science-pipelines-operator/manager/manager.yaml
@@ -4,24 +4,18 @@ metadata:
   name: controller-manager
   namespace: datasciencepipelinesapplications-controller
   labels:
-    control-plane: controller-manager
-    app.kubernetes.io/name: deployment
-    app.kubernetes.io/instance: controller-manager
-    app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: data-science-pipelines-operator
-    app.kubernetes.io/part-of: data-science-pipelines-operator
+    app.kubernetes.io/name: data-science-pipelines-operator
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: data-science-pipelines-operator
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
-        app.kubernetes.io/created-by: data-science-pipelines-operator
+        app.kubernetes.io/name: data-science-pipelines-operator
     spec:
       securityContext:
         runAsNonRoot: true

--- a/data-science-pipelines-operator/prometheus/monitor.yaml
+++ b/data-science-pipelines-operator/prometheus/monitor.yaml
@@ -9,4 +9,4 @@ spec:
       port: metrics
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: data-science-pipelines-operator

--- a/data-science-pipelines-operator/rbac/leader_election_role.yaml
+++ b/data-science-pipelines-operator/rbac/leader_election_role.yaml
@@ -3,11 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: role
-    app.kubernetes.io/instance: leader-election-role
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: data-science-pipelines-operator
-    app.kubernetes.io/part-of: data-science-pipelines-operator
+    app.kubernetes.io/name: data-science-pipelines-operator
   name: leader-election-role
 rules:
 - apiGroups:

--- a/data-science-pipelines-operator/rbac/leader_election_role_binding.yaml
+++ b/data-science-pipelines-operator/rbac/leader_election_role_binding.yaml
@@ -2,11 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/instance: leader-election-rolebinding
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: data-science-pipelines-operator
-    app.kubernetes.io/part-of: data-science-pipelines-operator
+    app.kubernetes.io/name: data-science-pipelines-operator
   name: leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/data-science-pipelines-operator/rbac/role.yaml
+++ b/data-science-pipelines-operator/rbac/role.yaml
@@ -229,3 +229,25 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+    - mcad.ibm.com
+  resources:
+    - appwrappers
+  verbs:
+    - create
+    - get
+    - list
+    - patch
+    - delete
+- apiGroups:
+    - ray.io
+  resources:
+    - rayclusters
+    - rayjobs
+    - rayservices
+  verbs:
+    - create
+    - get
+    - list
+    - patch
+    - delete

--- a/data-science-pipelines-operator/rbac/role_binding.yaml
+++ b/data-science-pipelines-operator/rbac/role_binding.yaml
@@ -2,11 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/instance: manager-rolebinding
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: data-science-pipelines-operator
-    app.kubernetes.io/part-of: data-science-pipelines-operator
+    app.kubernetes.io/name: data-science-pipelines-operator
   name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/data-science-pipelines-operator/rbac/service_account.yaml
+++ b/data-science-pipelines-operator/rbac/service_account.yaml
@@ -2,10 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: data-science-pipelines-operator
-    app.kubernetes.io/part-of: data-science-pipelines-operator
+    app.kubernetes.io/name: data-science-pipelines-operator
   name: controller-manager
   namespace: datasciencepipelinesapplications-controller


### PR DESCRIPTION
Depends on: 
* https://github.com/opendatahub-io/data-science-pipelines-operator/pull/210
* https://github.com/opendatahub-io/data-science-pipelines/pull/110


Related: 
* https://github.com/red-hat-data-services/odh-deployer/pull/364


Live builder image: quay.io/hukhan/rhods-operator-live-catalog:1.31.0-1 

Note I had to use dashboard image: `registry-proxy.engineering.redhat.com/rh-osbs/managed-open-data-hub-odh-operator-bundle-rhel8:v1.31.0-1` because live builder image doesn't seem to work on my device. 

Upstream sources used: 

<details> 

<summary> upstream_sources.yaml </summary> 

```yaml
git:
  # ODH Deployer
  - name: odh-deployer-container-live
    url: https://github.com/DharmitD/odh-deployer
    branch: dspo-labels
    patch: rhods-operator-live/dockerfiles/odh-deployer/Dockerfile

  # ODH Operator Base
  - name: odh-operator-base-container-live
    url: https://github.com/red-hat-data-services/opendatahub-operator
    branch: master
    patch: rhods-operator-live/dockerfiles/odh-operator-base/Dockerfile

  # ODH Operator
  - name: odh-operator-container-live
    url: https://github.com/HumairAK/odh-manifests
    branch: dsp_1-0-0
    patch: rhods-operator-live/dockerfiles/odh-operator/Dockerfile

  # ODH Dashboard
  - name: odh-dashboard-container-live
    url: https://github.com/red-hat-data-services/odh-dashboard
    branch: main
    patch: rhods-operator-live/dockerfiles/odh-dashboard/Dockerfile

  # Kubeflow Notebook Controller
  - name: odh-kf-notebook-controller-container-live
    url: https://github.com/red-hat-data-services/kubeflow
    branch: master
    context: components
    containerfile: notebook-controller/Dockerfile
    patch: rhods-operator-live/dockerfiles/odh-kf-notebook-controller/Dockerfile

  # ODH Notebook Controller
  - name: odh-notebook-controller-container-live
    url: https://github.com/red-hat-data-services/kubeflow
    branch: master
    context: components
    containerfile: odh-notebook-controller/Dockerfile
    patch: rhods-operator-live/dockerfiles/odh-notebook-controller/Dockerfile

  # ODH ML Pipelines Persistence Agent
  - name: odh-ml-pipelines-persistenceagent-container-live
    url: https://github.com/red-hat-data-services/data-science-pipelines
    branch: master
    containerfile: backend/src/Dockerfile.persistenceagent
    patch: rhods-operator-live/dockerfiles/odh-ml-pipelines-persistenceagent/Dockerfile

  # ODH ML Pipelines API Server
  - name: odh-ml-pipelines-api-server-container-live
    url: https://github.com/red-hat-data-services/data-science-pipelines
    branch: master
    containerfile: backend/src/Dockerfile
    patch: rhods-operator-live/dockerfiles/odh-ml-pipelines-api-server/Dockerfile

  # ML Pipelines Cacheserver
  - name: odh-ml-pipelines-cache-container-live
    url: https://github.com/red-hat-data-services/data-science-pipelines
    branch: master
    patch: rhods-operator-live/dockerfiles/odh-ml-pipelines-cache/Dockerfile

  # ML Pipelines Scheduled Workflow Server
  - name: odh-ml-pipelines-scheduledworkflow-container-live
    url: https://github.com/red-hat-data-services/data-science-pipelines
    branch: master
    patch: rhods-operator-live/dockerfiles/odh-ml-pipelines-scheduledworkflow/Dockerfile

  # ML Pipelines Artifact Manager
  - name: odh-ml-pipelines-artifact-manager-container-live
    url: https://github.com/red-hat-data-services/data-science-pipelines
    branch: master
    patch: rhods-operator-live/dockerfiles/odh-ml-pipelines-artifact-manager/Dockerfile

  # Data Science Pipelines Operator
  - name: odh-data-science-pipelines-operator-controller-container-live
    url: https://github.com/red-hat-data-services/data-science-pipelines-operator
    branch: main
    patch: rhods-operator-live/dockerfiles/odh-data-science-pipelines-operator-controller/Dockerfile

  # ODH Modelmesh Serving Controller
  - name: odh-modelmesh-serving-controller-container-live
    url: https://github.com/red-hat-data-services/modelmesh-serving
    branch: main
    patch: rhods-operator-live/dockerfiles/odh-modelmesh-serving-controller/Dockerfile

  # ODH Model Controller
  - name: odh-model-controller-container-live
    url: https://github.com/red-hat-data-services/odh-model-controller
    branch: main
    patch: rhods-operator-live/dockerfiles/odh-model-controller/Dockerfile

  # ODH Modelmesh Rest Proxy
  - name: odh-mm-rest-proxy-container-live
    url: https://github.com/red-hat-data-services/rest-proxy
    branch: main
    patch: rhods-operator-live/dockerfiles/odh-mm-rest-proxy/Dockerfile

  # ODH Modelmesh Serving Runtime sidecar
  - name: odh-modelmesh-container-live
    url: https://github.com/red-hat-data-services/modelmesh.git
    branch: main
    patch: rhods-operator-live/dockerfiles/odh-modelmesh/Dockerfile

  # ModelMesh Runtime Adapter sidecar
  - name: odh-modelmesh-runtime-adapter-container-live
    url: https://github.com/red-hat-data-services/modelmesh-runtime-adapter
    branch: main
    patch: rhods-operator-live/dockerfiles/odh-modelmesh-runtime-adapter/Dockerfile
    
  # TrustyAI Service
  - name: odh-trustyai-service-container-live
    url: https://github.com/red-hat-data-services/trustyai-explainability
    branch: main
    patch: rhods-operator-live/dockerfiles/odh-trustyai-service/Dockerfile

  # TrustyAI Service
  - name: odh-trustyai-service-operator-container-live
    url: https://github.com/red-hat-data-services/trustyai-service-operator
    branch: main
    patch: rhods-operator-live/dockerfiles/odh-trustyai-service-operator/Dockerfile

```

</details>

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
