### PR TITLE
Add missing dashboard permission roles

### DIFF
--- a/odh-dashboard/base/role.yaml
+++ b/odh-dashboard/base/role.yaml
@@ -122,3 +122,15 @@ rules:
       - list
     resources:
       - odhquickstarts
+  - apiGroups:
+      - template.openshift.io
+    verbs:
+      - '*'
+    resources:
+      - templates
+  - apiGroups:
+      - serving.kserve.io
+    verbs:
+      - '*'
+    resources:
+      - servingruntimes


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-9626, https://issues.redhat.com/browse/RHODS-9917
- [X] The Jira story is backed

Follow up from #415 targeting main
