### PR TITLE
Add templateDisablement to odhdashboardconfig CRD

### DIFF
--- a/odh-dashboard/base/odh-dashboard-crd.yaml
+++ b/odh-dashboard/base/odh-dashboard-crd.yaml
@@ -144,6 +144,10 @@ spec:
                   type: array
                   items:
                     type: string
+                templateDisablement:
+                  type: array
+                  items:
+                    type: string
             status:
               type: object
               properties:


### PR DESCRIPTION
Add templateDisablement to odhdashboardconfig CRD

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
