### PR TITLE
Sync OdhDashboardConfig with upstream

### DIFF
--- a/odh-dashboard/base/odh-dashboard-crd.yaml
+++ b/odh-dashboard/base/odh-dashboard-crd.yaml
@@ -148,19 +148,3 @@ spec:
                   type: array
                   items:
                     type: string
-            status:
-              type: object
-              properties:
-                notebookControllerState:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      user:
-                        type: string
-                      lastSelectedImage:
-                        type: string
-                      lastSelectedSize:
-                        type: string
-                      lastActivity:
-                        type: number


### PR DESCRIPTION
Syncing odh manifest to get the same attributes than upstream


- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
