### PR TITLE
Fix: missing file

### DIFF
--- a/modelmesh-monitoring/base/params.yaml
+++ b/modelmesh-monitoring/base/params.yaml
@@ -1,0 +1,10 @@
+varReference:
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment
+    apiVersion: apps/v1
+  - path: data
+    kind: ConfigMap
+  - path: spec/template/spec/containers[]/env/value
+    kind: Deployment
+  - path: subjects[]/namespace
+    kind: ClusterRoleBinding


### PR DESCRIPTION
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
this is missing in downstream, which has in https://github.com/opendatahub-io/odh-manifests/blob/master/modelmesh-monitoring/base/params.yaml


error
`023-07-27T16:38:40Z	ERROR	controllers.DataScienceCluster	failed to reconcile model-mesh on DataScienceCluster	{"instance.Name": "default", "error": "error during resmap resources: evalsymlink failure on '/opt/manifests/modelmesh-monitoring/base/params.yaml' : lstat /opt/manifests/modelmesh-monitoring/base/params.yaml: no such file or directory"}`
