### PR TITLE
Update to use correct Upstream ODH image repo

### DIFF
--- a/odh-dashboard/base/params.env
+++ b/odh-dashboard/base/params.env
@@ -1,1 +1,1 @@
-odh-dashboard-image=quay.io/modh/odh-dashboard-container:latest
+odh-dashboard-image=quay.io/opendatahub/odh-dashboard:latest

--- a/odh-notebook-controller/base/params.env
+++ b/odh-notebook-controller/base/params.env
@@ -1,2 +1,2 @@
-odh-kf-notebook-controller-image=quay.io/modh/odh-kf-notebook-controller-container:latest
-odh-notebook-controller-image=quay.io/modh/odh-notebook-controller-container:latest
+odh-kf-notebook-controller-image=quay.io/opendatahub/kubeflow-notebook-controller:latest
+odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:latest


### PR DESCRIPTION
Update to use correct image repo, useful for local testing with this repo
When for official RHODS build, these will be auto replaced with internal image repo

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
