### PR TITLE
Cherry-pick from odh-deployer for modelserving (OVMS)

### DIFF
--- a/odh-dashboard/modelserving/kustomization.yaml
+++ b/odh-dashboard/modelserving/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: odh-dashboard
+  app.kubernetes.io/part-of: odh-dashboard
+resources:
+  -  ovms-ootb.yaml
+  -  ovms-gpu-ootb.yaml
+images:
+  - name: ovms-1
+    newName: quay.io/opendatahub/openvino_model_server
+    digest: sha256:20dbfbaf53d1afbd47c612d953984238cb0e207972ed544a5ea662c2404f276d

--- a/odh-dashboard/modelserving/ovms-gpu-ootb-yaml
+++ b/odh-dashboard/modelserving/ovms-gpu-ootb-yaml
@@ -1,0 +1,63 @@
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: ovms-gpu
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/ootb: 'true'
+    opendatahub.io/configurable: 'true'
+  annotations:
+    tags: 'ovms,servingruntime'
+    description: 'OpenVino with GPU Support Model Serving Definition'
+objects:
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: ovms-gpu
+      annotations:
+        openshift.io/display-name: 'OpenVINO Model Server (Supports GPUs)'
+      labels:
+        opendatahub.io/dashboard: 'true'
+    spec:
+      builtInAdapter:
+        env:
+          - name: OVMS_FORCE_TARGET_DEVICE
+            value: NVIDIA
+        memBufferBytes: 134217728
+        modelLoadingTimeoutMillis: 90000
+        runtimeManagementPort: 8888
+        serverType: ovms
+      containers:
+        - args:
+            - '--port=8001'
+            - '--rest_port=8888'
+            - '--config_path=/models/model_config_list.json'
+            - '--file_system_poll_wait_seconds=0'
+            - '--grpc_bind_address=127.0.0.1'
+            - '--rest_bind_address=127.0.0.1'
+          image: ovms-1
+          name: ovms
+          resources:
+            limits:
+              cpu: '0'
+              memory: 0Gi
+            requests:
+              cpu: '0'
+              memory: 0Gi
+      grpcDataEndpoint: 'port:8001'
+      grpcEndpoint: 'port:8085'
+      multiModel: true
+      protocolVersions:
+        - grpc-v1
+      replicas: 1
+      supportedModelFormats:
+        - autoSelect: true
+          name: openvino_ir
+          version: opset1
+        - autoSelect: true
+          name: onnx
+          version: '1'
+        - autoSelect: true
+          name: tensorflow
+          version: "2"
+parameters: []

--- a/odh-dashboard/modelserving/ovms-ootb.yaml
+++ b/odh-dashboard/modelserving/ovms-ootb.yaml
@@ -1,0 +1,61 @@
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: ovms
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/ootb: 'true'
+    opendatahub.io/configurable: 'true'
+  annotations:
+    tags: 'ovms,servingruntime'
+    description: 'OpenVino Model Serving Definition'
+objects:
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: ovms
+      annotations:
+        openshift.io/display-name: 'OpenVINO Model Server'
+        opendatahub.io/disable-gpu: 'true'
+      labels:
+        opendatahub.io/dashboard: 'true'
+    spec:
+      builtInAdapter:
+        memBufferBytes: 134217728
+        modelLoadingTimeoutMillis: 90000
+        runtimeManagementPort: 8888
+        serverType: ovms
+      containers:
+        - args:
+            - '--port=8001'
+            - '--rest_port=8888'
+            - '--config_path=/models/model_config_list.json'
+            - '--file_system_poll_wait_seconds=0'
+            - '--grpc_bind_address=127.0.0.1'
+            - '--rest_bind_address=127.0.0.1'
+          image: ovms-1
+          name: ovms
+          resources:
+            limits:
+              cpu: '0'
+              memory: 0Gi
+            requests:
+              cpu: '0'
+              memory: 0Gi
+      grpcDataEndpoint: 'port:8001'
+      grpcEndpoint: 'port:8085'
+      multiModel: true
+      protocolVersions:
+        - grpc-v1
+      replicas: 1
+      supportedModelFormats:
+        - autoSelect: true
+          name: openvino_ir
+          version: opset1
+        - autoSelect: true
+          name: onnx
+          version: '1'
+        - autoSelect: true
+          name: tensorflow
+          version: "2"
+parameters: []


### PR DESCRIPTION
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

From https://github.com/red-hat-data-services/odh-deployer/tree/main/odh-dashboard/modelserving