### PR TITLE
Cherry-pick from odh-deploy for ConfigMap

### DIFF
--- a/odh-dashboard/config/kustomization.yaml
+++ b/odh-dashboard/config/kustomization.yaml
@@ -4,4 +4,4 @@ commonLabels:
   app: rhods-dashboard
   app.kubernetes.io/part-of: rhods-dashboard
 resources:
-- consolelink.yaml
+- odh-enabled-applications-config.configmap.yaml

--- a/odh-dashboard/config/odh-enabled-applications-config.configmap.yaml
+++ b/odh-dashboard/config/odh-enabled-applications-config.configmap.yaml
@@ -1,0 +1,7 @@
+# Enables the Jupyter Spawner UI for the notebook-controller
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: odh-enabled-applications-config
+data:
+  jupyter: 'true'


### PR DESCRIPTION
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

Cherry-pick from https://github.com/red-hat-data-services/odh-deployer/blob/main/odh-dashboard/configs/odh-enabled-applications-config.configmap.yaml