### PR TITLE
Prepare 1.31 release for the dashboard

### DIFF
--- a/odh-dashboard/base/odh-application-crd.yaml
+++ b/odh-dashboard/base/odh-application-crd.yaml
@@ -118,6 +118,7 @@ spec:
                 isEnabled:
                   type: boolean
                 kfdefApplications:
+                  description: "(Deprecated) Apps do not rely on other deployments, they are deployed by those components."
                   items:
                     type: string
                   type: array

--- a/odh-dashboard/base/odh-dashboard-crd.yaml
+++ b/odh-dashboard/base/odh-dashboard-crd.yaml
@@ -148,19 +148,3 @@ spec:
                   type: array
                   items:
                     type: string
-            status:
-              type: object
-              properties:
-                notebookControllerState:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      user:
-                        type: string
-                      lastSelectedImage:
-                        type: string
-                      lastSelectedSize:
-                        type: string
-                      lastActivity:
-                        type: number

--- a/odh-dashboard/base/role.yaml
+++ b/odh-dashboard/base/role.yaml
@@ -101,24 +101,36 @@ rules:
       - delete
     resources:
       - notebooks
-  - apiGroups:
-      - dashboard.opendatahub.io
-    verbs:
+  - verbs:
       - get
       - list
+    apiGroups:
+      - dashboard.opendatahub.io
     resources:
       - odhapplications
-  - apiGroups:
-      - dashboard.opendatahub.io
-    verbs:
+  - verbs:
       - get
       - list
+    apiGroups:
+      - dashboard.opendatahub.io
     resources:
       - odhdocuments
-  - apiGroups:
-      - console.openshift.io
-    verbs:
+  - verbs:
       - get
       - list
+    apiGroups:
+      - console.openshift.io
     resources:
       - odhquickstarts
+  - apiGroups:
+      - template.openshift.io
+    verbs:
+      - '*'
+    resources:
+      - templates
+  - apiGroups:
+      - serving.kserve.io
+    verbs:
+      - '*'
+    resources:
+      - servingruntimes

--- a/odh-dashboard/overlays/authentication/kustomization.yaml
+++ b/odh-dashboard/overlays/authentication/kustomization.yaml
@@ -33,4 +33,4 @@ patchesJson6902:
 images:
 - name: oauth-proxy
   newName: registry.redhat.io/openshift4/ose-oauth-proxy
-  digest: sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+  digest: sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33


### PR DESCRIPTION
Prepare 1.31 release, last one that is not using the rhods overlay.