### PR TITLE
Fix: missing placeholder for kuberay operator

### DIFF
--- a/ray/operator/base/kustomization.yaml
+++ b/ray/operator/base/kustomization.yaml
@@ -16,6 +16,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.namespace
+- name: odh-kuberay-operator-controller-image
+  objref:
+    kind: ConfigMap
+    name: ray-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.odh-kuberay-operator-controller-image
 
 resources:
 - ../crd
@@ -23,9 +30,3 @@ resources:
 - ../manager
 - ../prometheus
 - ../scc
-
-images:
-- name: kuberay/operator
-  newName: quay.io/opendatahub/kuberay-operator
-  newTag: v0.5.0
-

--- a/ray/operator/base/params.env
+++ b/ray/operator/base/params.env
@@ -1,1 +1,2 @@
 namespace=opendatahub
+odh-kuberay-operator-controller-image=quay.io/opendatahub/kuberay-operator:v0.5.0

--- a/ray/operator/base/params.yaml
+++ b/ray/operator/base/params.yaml
@@ -3,3 +3,5 @@ varReference:
     kind: ClusterRoleBinding
   - path: users[]
     kind: SecurityContextConstraints
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment

--- a/ray/operator/manager/manager.yaml
+++ b/ray/operator/manager/manager.yaml
@@ -25,9 +25,7 @@ spec:
       containers:
       - command:
         - /manager
-#        args:
-#        - --enable-leader-election
-        image: kuberay/operator
+        image: $(odh-kuberay-operator-controller-image)
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
we are missing new variable for ray to be replaced by CPaaS build env variable. 
cherry-pick https://github.com/opendatahub-io/odh-manifests/pull/911


- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
