### PR TITLE
Include accelerator profile to the Notebook images 

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-gpu-notebook-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/notebook-image-name: "CUDA"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and minimal dependency set to start experimenting with Jupyter environment."
     opendatahub.io/notebook-image-order: "30"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: minimal-gpu
 spec:
   lookupPolicy:

--- a/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/pytorch-notebook-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/notebook-image-name: "PyTorch"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "40"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: pytorch
 spec:
   lookupPolicy:

--- a/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/notebook-image-name: "TensorFlow"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "50"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: tensorflow
 spec:
   lookupPolicy:


### PR DESCRIPTION
Include the accelerator profile in the Notebook images

Related-to: https://github.com/opendatahub-io/notebooks/issues/151
https://github.com/opendatahub-io/odh-manifests/pull/915

Related-to: #488 

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s):
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
