### PR TITLE
rhods-1.34: Point to right KServe images using SHA256 pointers

### DIFF
--- a/kserve/base/params.env
+++ b/kserve/base/params.env
@@ -1,4 +1,4 @@
-kserve-controller=quay.io/opendatahub/kserve-controller:v0.11.0
-kserve-agent=quay.io/opendatahub/kserve-agent:v0.11.0
-kserve-router=quay.io/opendatahub/kserve-router:v0.11.0
-kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:v0.11.0
+kserve-controller=quay.io/modh/kserve-controller@sha256:cadb620f1516440e881217c447c92956778abc0656788c94c19ef0070e865019
+kserve-agent=quay.io/modh/kserve-agent@sha256:126b3962d616ad9d0758b905610df27006be1008bd84f029260896c8b8e689b3
+kserve-router=quay.io/modh/kserve-router@sha256:c11d3b0fb1913232a7daead2d44bd0a946c32673e983904ca674aabc4a2cfc3a
+kserve-storage-initializer=quay.io/modh/kserve-storage-initializer@sha256:fa096fae58009df0af4daa175305a683266baf49268facf1a6dc934ec620e58a


### PR DESCRIPTION
These images are from 
- https://quay.io/repository/modh/kserve-controller?tab=tags&tag=latest
- https://quay.io/repository/modh/kserve-storage-initializer
- https://quay.io/repository/modh/kserve-agent
- https://quay.io/repository/modh/kserve-router
