### PR TITLE
Add TrustyAI Operator Manifests from Upstream

### DIFF
--- a/trustyai-service-operator/OWNERS
+++ b/trustyai-service-operator/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+  - robgeada
+  - ruivieira
+  - tteofili
+  
+approvers:
+  - robgeada
+  - ruivieira
+  - tteofili

--- a/trustyai-service-operator/README.md
+++ b/trustyai-service-operator/README.md
@@ -1,0 +1,141 @@
+[![Controller Tests](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/controller-tests.yaml/badge.svg)](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/controller-tests.yaml)
+# TrustyAI Kubernetes Operator
+
+## Overview
+
+The TrustyAI Kubernetes Operator aims at simplifying the deployment and management of the [TrustyAI service](https://github.com/trustyai-explainability/trustyai-explainability/tree/main/explainability-service) on Kubernetes and OpenShift clusters by watching for custom resources of kind `TrustyAIService` in the `trustyai.opendatahub.io` API group and manages deployments, services, and optionally, routes and `ServiceMonitors` corresponding to these resources.
+
+The operator ensures the service is properly configured, is discoverable by Prometheus for metrics scraping (on both Kubernetes and OpenShift), and is accessible via a Route on OpenShift.
+
+## Prerequisites
+
+- Kubernetes cluster v1.19+ or OpenShift cluster v4.6+
+- `kubectl` v1.19+ or `oc` client v4.6+
+
+## Installation using pre-built Operator image
+
+This operator is available as an [image on Quay.io](https://quay.io/repository/trustyai/trustyai-service-operator?tab=history). 
+To deploy it on your cluster:
+
+1. **Install the Custom Resource Definition (CRD):**
+
+   Apply the CRD to your cluster (replace the URL with the relevant one, if using another repository):
+
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/trustyai-explainability/trustyai-service-operator/main/config/crd/bases/trustyai.opendatahub.io.trustyai.opendatahub.io_trustyaiservices.yaml
+    ```
+
+2. **Deploy the Operator:**
+
+   Apply the following Kubernetes manifest to deploy the operator:
+
+    ```yaml
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: trustyai-operator
+      namespace: trustyai-operator-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          control-plane: trustyai-operator
+      template:
+        metadata:
+          labels:
+            control-plane: trustyai-operator
+        spec:
+          containers:
+            - name: trustyai-operator
+              image: quay.io/trustyai/trustyai-service-operator:latest
+              command:
+                - /manager
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 30Mi
+                requests:
+                  cpu: 100m
+                  memory: 20Mi
+    ```
+
+   or run
+
+   ```shell
+   kubectl apply -f https://raw.githubusercontent.com/trustyai-explainability/trustyai-service-operator/main/artifacts/examples/deploy-operator.yaml   
+   ```
+
+## Usage
+
+Once the operator is installed, you can create `TrustyAIService` resources, and the operator will create corresponding TrustyAI deployments, services, and (on OpenShift) routes.
+
+Here's an example `TrustyAIService` manifest:
+
+```yaml
+apiVersion: trustyai.opendatahub.io.trusty.opendatahub.io/v1
+kind: TrustyAIService
+metadata:
+  name: trustyai-service-example
+spec:
+  storage:
+    format: "PVC"
+    folder: "/inputs"
+    size: "1Gi"
+  data:
+    filename: "data.csv"
+    format: "CSV"
+  metrics:
+    schedule: "5s"
+    batchSize: 5000 # Optional, defaults to 5000
+```
+
+You can apply this manifest with 
+
+```shell
+kubectl apply -f <file-name.yaml> -n $NAMESPACE
+```
+to create a service, where `$NAMESPACE` is the namespace where you want to deploy it.
+
+
+Additionally, in that namespace:
+
+* a `ServiceMonitor` will be created to allow Prometheus to scrape metrics from the service.
+* (if on OpenShift) a `Route` will be created to allow external access to the service.
+
+### Custom Image Configuration using ConfigMap
+
+You can configure the operator to use custom images by creating a `ConfigMap` in the operator's namespace. 
+The operator only checks the ConfigMap at deployment, so changes made afterward won't trigger a redeployment of services.
+
+Here's an example of a ConfigMap that specifies a custom image:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trustyai-service-operator-config
+data:
+  trustyaiServiceImageName: 'quay.io/mycustomrepo/mycustomimage'
+  trustyaiServiceImageTag: 'v1.0.0'
+```
+
+You can apply this manifest with the following command, replacing `<file-name.yaml>` with the name of your manifest file:
+
+```shell
+kubectl apply -f <file-name.yaml> -n $OPERATOR_NAMESPACE
+```
+
+Please ensure the namespace specified is the same as the namespace where you have deployed the operator.
+
+After the ConfigMap is applied, you can then proceed to deploy the TrustyAI service.
+The operator will use the image name and tag specified in the ConfigMap for the deployment.
+
+If you want to use a different image or tag in the future, you'll need to update the ConfigMap and redeploy the operator to have the changes take effect. The running TrustyAI services won't be redeployed automatically. To use the new image or tag, you'll need to delete and recreate the TrustyAIService resources.
+
+## Contributing
+
+Please see the [CONTRIBUTING.md](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md) file for more details on how to contribute to this project.
+
+## License
+
+This project is licensed under the Apache License Version 2.0 - see the [LICENSE](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/LICENSE) file for details.

--- a/trustyai-service-operator/base/kustomization.yaml
+++ b/trustyai-service-operator/base/kustomization.yaml
@@ -1,0 +1,40 @@
+#namespace: trustyai-service-operator-system
+
+namePrefix: trustyai-service-operator-
+
+resources:
+- ../crd
+- ../rbac
+- ../manager
+
+commonLabels:
+  app.kubernetes.io/part-of: trustyai
+
+patchesStrategicMerge:
+- manager_auth_proxy_patch.yaml
+
+configMapGenerator:
+  - env: params.env
+    name: config
+
+configurations:
+  - params.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+  - name: trustyaiServiceImage
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.trustyaiServiceImage
+  - name: trustyaiOperatorImage
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.trustyaiOperatorImage

--- a/trustyai-service-operator/base/manager_auth_proxy_patch.yaml
+++ b/trustyai-service-operator/base/manager_auth_proxy_patch.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+      containers:
+      - name: kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      - name: manager
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"

--- a/trustyai-service-operator/base/manager_config_patch.yaml
+++ b/trustyai-service-operator/base/manager_config_patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager

--- a/trustyai-service-operator/base/params.env
+++ b/trustyai-service-operator/base/params.env
@@ -1,0 +1,2 @@
+trustyaiServiceImage=quay.io/trustyai/trustyai-service:v0.6.0
+trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:v1.11.0

--- a/trustyai-service-operator/base/params.yaml
+++ b/trustyai-service-operator/base/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+  - kind: Deployment
+    path: spec/template/spec/containers[]/image

--- a/trustyai-service-operator/crd/bases/trustyai.opendatahub.io.trustyai.opendatahub.io_trustyaiservices.yaml
+++ b/trustyai-service-operator/crd/bases/trustyai.opendatahub.io.trustyai.opendatahub.io_trustyaiservices.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: trustyaiservices.trustyai.opendatahub.io.trustyai.opendatahub.io
+spec:
+  group: trustyai.opendatahub.io.trustyai.opendatahub.io
+  names:
+    kind: TrustyAIService
+    listKind: TrustyAIServiceList
+    plural: trustyaiservices
+    singular: trustyaiservice
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TrustyAIService is the Schema for the trustyaiservices API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TrustyAIServiceSpec defines the desired state of TrustyAIService
+            properties:
+              data:
+                properties:
+                  filename:
+                    type: string
+                  format:
+                    type: string
+                required:
+                - filename
+                - format
+                type: object
+              metrics:
+                properties:
+                  batchSize:
+                    type: integer
+                  schedule:
+                    type: string
+                required:
+                - schedule
+                type: object
+              replicas:
+                description: Number of replicas
+                format: int32
+                type: integer
+              storage:
+                properties:
+                  folder:
+                    type: string
+                  format:
+                    type: string
+                  size:
+                    type: string
+                required:
+                - folder
+                - format
+                - size
+                type: object
+            required:
+            - data
+            - metrics
+            - storage
+            type: object
+          status:
+            description: TrustyAIServiceStatus defines the observed state of TrustyAIService
+            properties:
+              conditions:
+                items:
+                  description: Condition represents possible conditions of a TrustyAIServiceStatus
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Define your status fields here
+                type: string
+              ready:
+                type: string
+              replicas:
+                format: int32
+                type: integer
+            required:
+            - conditions
+            - phase
+            - replicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/trustyai-service-operator/crd/kustomization.yaml
+++ b/trustyai-service-operator/crd/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- bases/trustyai.opendatahub.io.trustyai.opendatahub.io_trustyaiservices.yaml
+#+kubebuilder:scaffold:crdkustomizeresource
+
+patchesStrategicMerge:
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+configurations:
+- kustomizeconfig.yaml

--- a/trustyai-service-operator/crd/kustomizeconfig.yaml
+++ b/trustyai-service-operator/crd/kustomizeconfig.yaml
@@ -1,0 +1,18 @@
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: CustomResourceDefinition
+    version: v1
+    group: apiextensions.k8s.io
+    path: spec/conversion/webhook/clientConfig/service/name
+
+namespace:
+- kind: CustomResourceDefinition
+  version: v1
+  group: apiextensions.k8s.io
+  path: spec/conversion/webhook/clientConfig/service/namespace
+  create: false
+
+varReference:
+- path: metadata/annotations

--- a/trustyai-service-operator/crd/patches/cainjection_in_trustyaiservices.yaml
+++ b/trustyai-service-operator/crd/patches/cainjection_in_trustyaiservices.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: trustyaiservices.trustyai.opendatahub.io.trustyai.opendatahub.io

--- a/trustyai-service-operator/crd/patches/webhook_in_trustyaiservices.yaml
+++ b/trustyai-service-operator/crd/patches/webhook_in_trustyaiservices.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: trustyaiservices.trustyai.opendatahub.io.trustyai.opendatahub.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1

--- a/trustyai-service-operator/manager/kustomization.yaml
+++ b/trustyai-service-operator/manager/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/trustyai-service-operator/manager/manager.yaml
+++ b/trustyai-service-operator/manager/manager.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: trustyai-service-operator
+    app.kubernetes.io/part-of: trustyai-service-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - command:
+        - /manager
+        args:
+        - --leader-elect
+        image: $(trustyaiOperatorImage)
+        name: manager
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+          seccompProfile:
+            type: RuntimeDefault
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10

--- a/trustyai-service-operator/manifests/kustomization.yaml
+++ b/trustyai-service-operator/manifests/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- bases/trustyai-service-operator.clusterserviceversion.yaml
+- ../default
+- ../samples
+- ../scorecard

--- a/trustyai-service-operator/prometheus/kustomization.yaml
+++ b/trustyai-service-operator/prometheus/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- monitor.yaml

--- a/trustyai-service-operator/prometheus/monitor.yaml
+++ b/trustyai-service-operator/prometheus/monitor.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: trustyai-service-operator
+    app.kubernetes.io/part-of: trustyai-service-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/trustyai-service-operator/rbac/auth_proxy_client_clusterrole.yaml
+++ b/trustyai-service-operator/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: trustyai-service-operator
+    app.kubernetes.io/part-of: trustyai-service-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/trustyai-service-operator/rbac/auth_proxy_role.yaml
+++ b/trustyai-service-operator/rbac/auth_proxy_role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: proxy-role
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: trustyai-service-operator
+    app.kubernetes.io/part-of: trustyai-service-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/trustyai-service-operator/rbac/auth_proxy_role_binding.yaml
+++ b/trustyai-service-operator/rbac/auth_proxy_role_binding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: proxy-rolebinding
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: trustyai-service-operator
+    app.kubernetes.io/part-of: trustyai-service-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/trustyai-service-operator/rbac/auth_proxy_service.yaml
+++ b/trustyai-service-operator/rbac/auth_proxy_service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: trustyai-service-operator
+    app.kubernetes.io/part-of: trustyai-service-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/trustyai-service-operator/rbac/kustomization.yaml
+++ b/trustyai-service-operator/rbac/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- service_account.yaml
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml
+- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
+- auth_proxy_client_clusterrole.yaml

--- a/trustyai-service-operator/rbac/leader_election_role.yaml
+++ b/trustyai-service-operator/rbac/leader_election_role.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: trustyai-service-operator
+    app.kubernetes.io/part-of: trustyai-service-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/trustyai-service-operator/rbac/leader_election_role_binding.yaml
+++ b/trustyai-service-operator/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: trustyai-service-operator
+    app.kubernetes.io/part-of: trustyai-service-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/trustyai-service-operator/rbac/role.yaml
+++ b/trustyai-service-operator/rbac/role.yaml
@@ -1,0 +1,176 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - list
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferenceservices
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferenceservices/finalizers
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - servingruntimes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - servingruntimes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  resources:
+  - trustyaiservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  resources:
+  - trustyaiservices/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  resources:
+  - trustyaiservices/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/trustyai-service-operator/rbac/role_binding.yaml
+++ b/trustyai-service-operator/rbac/role_binding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: trustyai-service-operator
+    app.kubernetes.io/part-of: trustyai-service-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/trustyai-service-operator/rbac/service_account.yaml
+++ b/trustyai-service-operator/rbac/service_account.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: trustyai-service-operator
+    app.kubernetes.io/part-of: trustyai-service-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager
+  namespace: system

--- a/trustyai-service-operator/rbac/trustyaiservice_editor_role.yaml
+++ b/trustyai-service-operator/rbac/trustyaiservice_editor_role.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: trustyaiservice-editor-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: trustyai-service-operator
+    app.kubernetes.io/part-of: trustyai-service-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: trustyaiservice-editor-role
+rules:
+- apiGroups:
+  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  resources:
+  - trustyaiservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  resources:
+  - trustyaiservices/status
+  verbs:
+  - get

--- a/trustyai-service-operator/rbac/trustyaiservice_viewer_role.yaml
+++ b/trustyai-service-operator/rbac/trustyaiservice_viewer_role.yaml
@@ -1,0 +1,27 @@
+# permissions for end users to view trustyaiservices.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: trustyaiservice-viewer-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: trustyai-service-operator
+    app.kubernetes.io/part-of: trustyai-service-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: trustyaiservice-viewer-role
+rules:
+- apiGroups:
+  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  resources:
+  - trustyaiservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  resources:
+  - trustyaiservices/status
+  verbs:
+  - get

--- a/trustyai-service-operator/scorecard/bases/config.yaml
+++ b/trustyai-service-operator/scorecard/bases/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests: []

--- a/trustyai-service-operator/scorecard/kustomization.yaml
+++ b/trustyai-service-operator/scorecard/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+- bases/config.yaml
+patchesJson6902:
+- path: patches/basic.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config
+- path: patches/olm.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config
+#+kubebuilder:scaffold:patchesJson6902

--- a/trustyai-service-operator/scorecard/patches/basic.config.yaml
+++ b/trustyai-service-operator/scorecard/patches/basic.config.yaml
@@ -1,0 +1,10 @@
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.28.1
+    labels:
+      suite: basic
+      test: basic-check-spec-test

--- a/trustyai-service-operator/scorecard/patches/olm.config.yaml
+++ b/trustyai-service-operator/scorecard/patches/olm.config.yaml
@@ -1,0 +1,50 @@
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.28.1
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.28.1
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.28.1
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.28.1
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.28.1
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test


### PR DESCRIPTION
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
