### PR TITLE
[hotfix] Patch the imagestream by removing habana 1.11.0

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/habana-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/habana-notebook-imagestream.yaml
@@ -14,25 +14,15 @@ spec:
   lookupPolicy:
     local: true
   tags:
-  # 1.11.0 Version of the image n
-  - annotations:
-      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"Habana","version":"1.11"}]'
-      opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.23"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Tensorflow","version":"2.12.1"},{"name":"PyTorch","version":"2.0.1"},{"name":"Elyra","version":"3.15"}]'
-      openshift.io/imported-from: quay.io/modh/odh-habana-notebooks
-    from:
-      kind: DockerImage
-      name: $(odh-habana-notebook-image-n)
-    name: "2023.2"
-    referencePolicy:
-      type: Source
   # 1.10.0 Version of the image n-1
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"Habana","version":"1.10"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.23"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Tensorflow","version":"2.12.0"},{"name":"PyTorch","version":"2.0.1"},{"name":"Elyra","version":"3.15"}]'
       openshift.io/imported-from: quay.io/modh/odh-habana-notebooks
+      opendatahub.io/workbench-image-recommended: 'true'
     from:
       kind: DockerImage
-      name: $(odh-habana-notebook-image-n-1)
+      name: $(odh-habana-notebook-image-n)
     name: "2023.1"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/kustomization.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/kustomization.yaml
@@ -105,12 +105,5 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-habana-notebook-image-n
-  - name: odh-habana-notebook-image-n-1
-    objref:
-      kind: ConfigMap
-      name: notebooks-parameters
-      apiVersion: v1
-    fieldref:
-      fieldpath: data.odh-habana-notebook-image-n-1
 configurations:
   - params.yaml

--- a/jupyterhub/notebook-images/overlays/additional/params.env
+++ b/jupyterhub/notebook-images/overlays/additional/params.env
@@ -9,5 +9,4 @@ odh-generic-data-science-notebook-image-n-1=quay.io/modh/odh-generic-data-scienc
 odh-tensorflow-gpu-notebook-image-n=quay.io/modh/cuda-notebooks@sha256:9dfc60575154eb58e22577ae7287bb61d2145eb0129a36c446c43bf54f1136b5
 odh-tensorflow-gpu-notebook-image-n-1=quay.io/modh/cuda-notebooks@sha256:2163ba74f602ec4b3049a88dcfa4fe0a8d0fff231090001947da66ef8e75ab9a
 odh-trustyai-notebook-image-n=quay.io/modh/odh-trustyai-notebook@sha256:b8a351d77d54b1fbf469885002e0db2a6649b605ff8c2c5bb2056709304b6db0
-odh-habana-notebook-image-n=quay.io/modh/odh-habana-notebooks@sha256:56041d1d4588105a3b21256cb9fc976d4673a2640b321674ba5379fbb6edea8b
-odh-habana-notebook-image-n-1=quay.io/modh/odh-habana-notebooks@sha256:25e43ae89f7f509170bf5a58ce98376e9ae9637d5054ae4e7dc83498f15dd874
+odh-habana-notebook-image-n=quay.io/modh/odh-habana-notebooks@sha256:25e43ae89f7f509170bf5a58ce98376e9ae9637d5054ae4e7dc83498f15dd874

--- a/jupyterhub/notebook-images/overlays/additional/params.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/params.yaml
@@ -47,7 +47,3 @@ varReference:
   kind: ImageStream
   apiGroup: image.openshift.io/v1
   name: odh-habana-notebook-image-n
-- path: spec/tags[]/from/name
-  kind: ImageStream
-  apiGroup: image.openshift.io/v1
-  name: odh-habana-notebook-image-n-1


### PR DESCRIPTION
Patch the imagestream by removing habana 1.11.0
Related-to: https://github.com/opendatahub-io/notebooks/issues/297