### PR TITLE
[RHODS-1.34] hot-fix: Fix the imagestream minimal-cuda sha

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/params.env
+++ b/jupyterhub/notebook-images/overlays/additional/params.env
@@ -1,6 +1,6 @@
 odh-minimal-notebook-image-n=quay.io/modh/odh-minimal-notebook-container@sha256:54a5af13057df3445f917494a8cc12a0bed081c67204e00c9ed26daeaf9d0079
 odh-minimal-notebook-image-n-1=quay.io/modh/odh-minimal-notebook-container@sha256:39068767eebdf3a127fe8857fbdaca0832cdfef69eed6ec3ff6ed1858029420f
-odh-minimal-gpu-notebook-image-n=quay.io/modh/cuda-notebooks@sha256:32d6dd081b7f07e0c221378737aaa23a6f2275ee799613c393dbd323175737e
+odh-minimal-gpu-notebook-image-n=quay.io/modh/cuda-notebooks@sha256:32d6dd081b7f07e0c221378737aaa23a6f2275ee799613c393dbd323175737e8
 odh-minimal-gpu-notebook-image-n-1=quay.io/modh/cuda-notebooks@sha256:00c53599f5085beedd0debb062652a1856b19921ccf59bd76134471d24c3fa7d
 odh-pytorch-gpu-notebook-image-n=quay.io/modh/odh-pytorch-notebook@sha256:52200670fc0cacf74f5bc88e226a4baced2f325e33213f3c73e1f7e410f81fea
 odh-pytorch-gpu-notebook-image-n-1=quay.io/modh/odh-pytorch-notebook@sha256:b68e0192abf7d46c8c6876d0819b66c6a2d4a1e674f8893f8a71ffdcba96866c


### PR DESCRIPTION
[RHODS-1.34] hot-fix: Fix the imagestream minimal-cuda sha
JIRA: https://issues.redhat.com/browse/RHODS-12774