### PR TITLE
Remove the CRD feature flag for bias metrics

### DIFF
--- a/odh-dashboard/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/odh-dashboard/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -51,8 +51,6 @@ spec:
                       type: boolean
                     disablePipelines:
                       type: boolean
-                    disableBiasMetrics:
-                      type: boolean
                     disablePerformanceMetrics:
                       type: boolean
                     disableKServe:


### PR DESCRIPTION
Drops the feature flag for bias metrics -- will update all CRs when updated on a cluster effectively disabling the configuration.